### PR TITLE
Introduced SimpleLandmarkingInteractor object and made it the default interactor

### DIFF
--- a/src/main/scala/scalismo/ui/api/Interactors.scala
+++ b/src/main/scala/scalismo/ui/api/Interactors.scala
@@ -92,15 +92,10 @@ case class SimpleLandmarkingInteractor(ui: ScalismoUI) extends SimpleInteractor 
  */
 case class OneClickLandmarkingInteractor(ui: ScalismoUI, uncertainty: Uncertainty = Uncertainty.DefaultUncertainty) extends SimpleInteractor {
 
-  override type ConcreteInteractor = Instance
+  override type ConcreteInteractor = scalismo.ui.control.interactor.landmark.simple.SimpleLandmarkingInteractor.type
 
-  private[api] class Instance() extends SimpleLandmarkingInteractorTrait {
 
-    override val defaultUncertainty = uncertainty
+  override protected[api] lazy val peer = scalismo.ui.control.interactor.landmark.simple.SimpleLandmarkingInteractor
 
-    override def mousePressed(e: MouseEvent): Verdict = Recipe.Block2DRotation.mousePressed(e)
-  }
-
-  override protected[api] lazy val peer: Instance = new Instance()
 }
 

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
@@ -18,14 +18,14 @@
 package scalismo.ui.control.interactor.landmark.simple
 
 import java.awt.event.MouseEvent
-import java.awt.{ Color, Cursor }
+import java.awt.{Color, Cursor}
 import javax.swing.SwingUtilities
 
 import scalismo.ui.control.interactor.Interactor.Verdict
 import scalismo.ui.control.interactor.Interactor.Verdict.Pass
-import scalismo.ui.control.interactor.{ Interactor, Recipe }
+import scalismo.ui.control.interactor.{DefaultInteractor, Interactor, Recipe}
 import scalismo.ui.model.properties.Uncertainty
-import scalismo.ui.model.{ LandmarkNode, SceneNode }
+import scalismo.ui.model.{LandmarkNode, SceneNode}
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.view.ScalismoFrame
 
@@ -88,4 +88,12 @@ trait SimpleLandmarkingInteractorTrait extends Interactor {
     super.mouseMoved(e)
   }
 
+}
+
+
+object SimpleLandmarkingInteractor  extends SimpleLandmarkingInteractorTrait with DefaultInteractor {
+
+  override val defaultUncertainty = Uncertainty.DefaultUncertainty
+
+  override def mousePressed(e: MouseEvent): Verdict = Recipe.Block2DRotation.mousePressed(e)
 }

--- a/src/main/scala/scalismo/ui/view/ScalismoFrame.scala
+++ b/src/main/scala/scalismo/ui/view/ScalismoFrame.scala
@@ -18,10 +18,15 @@
 package scalismo.ui.view
 
 import java.awt.Dimension
-import javax.swing.{ SwingUtilities, WindowConstants }
+import java.awt.event.MouseEvent
+import javax.swing.{SwingUtilities, WindowConstants}
 
 import scalismo.ui.control.SceneControl
+import scalismo.ui.control.interactor.Interactor.Verdict
+import scalismo.ui.control.interactor.{DefaultInteractor, Recipe}
 import scalismo.ui.control.interactor.landmark.complex.ComplexLandmarkingInteractor
+import scalismo.ui.control.interactor.landmark.simple.{SimpleLandmarkingInteractor, SimpleLandmarkingInteractorTrait}
+import scalismo.ui.model.properties.Uncertainty
 
 //import scalismo.ui.control.interactor.landmark.complex.posterior.PosteriorLandmarkingInteractor
 import scalismo.ui.control.interactor.Interactor
@@ -182,7 +187,7 @@ class ScalismoFrame(val scene: Scene) extends MainFrame with ScalismoPublisher {
     }
   }
 
-  private var _interactor: Interactor = new ComplexLandmarkingInteractor.Instance(this)
+  private var _interactor: Interactor = SimpleLandmarkingInteractor
 
   def interactor: Interactor = _interactor
 


### PR DESCRIPTION
The current default landmarking interactor in Scalismo-ui is designed such that the user can specify a landmark uncertainty. Therefore at least two clicks (a left and right click) are needed to set a landmark. This is confusing to the uninitiated user, and is very often not what is needed. 

This PR therefore sets the default landmarking interactor to the SimpleLandmarkingInteractor, which requires just a single left click to set a landmark, and sets the uncertainty to the default uncertainty of 1mm stddev. 