### PR TITLE
Make simple-api pure api, introduce ScalismoNullUI

### DIFF
--- a/src/main/scala/scalismo/ui/api/FindInScene.scala
+++ b/src/main/scala/scalismo/ui/api/FindInScene.scala
@@ -25,7 +25,7 @@ import scalismo.ui.view.ScalismoFrame
  * able to search for a view
  */
 protected[api] trait FindInScene[V] {
-  def createView(s: SceneNode, frame: ScalismoFrame): Option[V]
+  def createView(s: SceneNode): Option[V]
 
 }
 

--- a/src/main/scala/scalismo/ui/api/Interactors.scala
+++ b/src/main/scala/scalismo/ui/api/Interactors.scala
@@ -52,7 +52,7 @@ case class SimplePosteriorLandmarkingInteractor(ui: ScalismoUI, modelGroup: Grou
     val meshView = ui.find[TriangleMeshView](modelGroup, (p: TriangleMeshView) => true).get
     //  val shapeTransformationView = ui.find[DiscreteLowRankGPTransformationView](modelGroup, (p: DiscreteLowRankGPTransformationView) => true).get
 
-    private val previewGroup = Group(ui.frame.scene.groups.add("__preview__", ghost = true), ui.frame)
+    private val previewGroup = Group(ui.frame.scene.groups.add("__preview__", ghost = true))
 
     // we start by copying the shape model transformations of the modelGroup into the previewGroup
     modelGroup.peer.shapeModelTransformations.poseTransformation.map(p => previewGroup.peer.shapeModelTransformations.addPoseTransformation(p.transformation))
@@ -63,7 +63,7 @@ case class SimplePosteriorLandmarkingInteractor(ui: ScalismoUI, modelGroup: Grou
     previewNode.color.value = Color.YELLOW
     previewNode.pickable.value = false
 
-    override val targetUncertaintyGroup = Group(ui.frame.scene.groups.add("__target_preview__", ghost = true), ui.frame).peer
+    override val targetUncertaintyGroup = Group(ui.frame.scene.groups.add("__target_preview__", ghost = true)).peer
 
     override def sourceGpNode: TransformationNode[DiscreteLowRankGpPointTransformation] = modelGroup.peer.shapeModelTransformations.gaussianProcessTransformation.get
 

--- a/src/main/scala/scalismo/ui/api/ScalismoNullUI.scala
+++ b/src/main/scala/scalismo/ui/api/ScalismoNullUI.scala
@@ -16,22 +16,12 @@
  */
 
 package scalismo.ui.api
+import scalismo.ui.model.Scene
 
-import scalismo.ui.view.ScalismoFrame
+case class ScalismoNullUI() extends SimpleAPI with SimpleAPIDefaultImpl {
 
-/**
- * This typeclass needs to be implemented if callbacks should be allowed for a view V
- */
-protected[api] trait HandleCallback[V] {
-  // calls function f if a node with type A has been added to the group g
-  def registerOnAdd[R](g: Group, f: V => R)
+  override def scene: Scene = new Scene
 
-  // calls function f if a node with type A has been removed from the group g
-  def registerOnRemove[R](g: Group, f: V => R)
-
-}
-
-object HandleCallback {
-  def apply[A](implicit a: HandleCallback[A]): HandleCallback[A] = a
+  override def visibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]): Unit = ()
 
 }

--- a/src/main/scala/scalismo/ui/api/ScalismoNullUI.scala
+++ b/src/main/scala/scalismo/ui/api/ScalismoNullUI.scala
@@ -22,6 +22,6 @@ case class ScalismoNullUI() extends SimpleAPI with SimpleAPIDefaultImpl {
 
   override def scene: Scene = new Scene
 
-  override def visibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]): Unit = ()
+  override def setVisibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]): Unit = ()
 
 }

--- a/src/main/scala/scalismo/ui/api/ScalismoUI.scala
+++ b/src/main/scala/scalismo/ui/api/ScalismoUI.scala
@@ -45,7 +45,7 @@ class ScalismoUI(title: String) extends SimpleAPI with SimpleAPIDefaultImpl {
   protected[api] val scene = fr.scene
   protected[api] val frame = fr
 
-  override def visibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]) = {
+  override def setVisibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]) = {
 
     def setVisible(isVisible: Boolean, viewportName: String): Unit = {
       frame.perspective.viewports.filter(_.name == viewportName).headOption.foreach { viewPort =>

--- a/src/main/scala/scalismo/ui/api/ShowInScene.scala
+++ b/src/main/scala/scalismo/ui/api/ShowInScene.scala
@@ -34,7 +34,7 @@ import scala.util.Try
 trait ShowInScene[-A] {
   type View
 
-  def showInScene(a: A, name: String, group: Group, frame: ScalismoFrame): View
+  def showInScene(a: A, name: String, group: Group): View
 
 }
 
@@ -45,16 +45,16 @@ trait LowPriorityImplicits {
   implicit def showInSceneScalarField[A: Scalar: ClassTag] = new ShowInScene[DiscreteScalarField[_3D, A]] {
     override type View = ScalarFieldView
 
-    override def showInScene(sf: DiscreteScalarField[_3D, A], name: String, group: Group, frame: ScalismoFrame): ScalarFieldView = {
-      ScalarFieldView(group.peer.scalarFields.add(sf, name), frame)
+    override def showInScene(sf: DiscreteScalarField[_3D, A], name: String, group: Group): ScalarFieldView = {
+      ScalarFieldView(group.peer.scalarFields.add(sf, name))
     }
   }
 
   implicit object CreateGenericTransformation extends ShowInScene[Point[_3D] => Point[_3D]] {
     override type View = TransformationView
 
-    override def showInScene(t: (Point[_3D]) => Point[_3D], name: String, group: Group, frame: ScalismoFrame): View = {
-      TransformationView(group.peer.genericTransformations.add(t, name), frame)
+    override def showInScene(t: (Point[_3D]) => Point[_3D], name: String, group: Group): View = {
+      TransformationView(group.peer.genericTransformations.add(t, name))
     }
   }
 
@@ -65,9 +65,9 @@ object ShowInScene extends LowPriorityImplicits {
   implicit object ShowInSceneMesh extends ShowInScene[TriangleMesh[_3D]] {
     override type View = TriangleMeshView
 
-    override def showInScene(mesh: TriangleMesh[_3D], name: String, group: Group, frame: ScalismoFrame): TriangleMeshView = {
+    override def showInScene(mesh: TriangleMesh[_3D], name: String, group: Group): TriangleMeshView = {
       val groupNode = group.peer
-      TriangleMeshView(groupNode.triangleMeshes.add(mesh, name), frame)
+      TriangleMeshView(groupNode.triangleMeshes.add(mesh, name))
     }
 
   }
@@ -75,9 +75,9 @@ object ShowInScene extends LowPriorityImplicits {
   implicit object ShowInSceneLineMesh extends ShowInScene[LineMesh[_3D]] {
     override type View = LineMeshView
 
-    override def showInScene(mesh: LineMesh[_3D], name: String, group: Group, frame: ScalismoFrame): LineMeshView = {
+    override def showInScene(mesh: LineMesh[_3D], name: String, group: Group): LineMeshView = {
       val groupNode = group.peer
-      LineMeshView(groupNode.lineMeshes.add(mesh, name), frame)
+      LineMeshView(groupNode.lineMeshes.add(mesh, name))
     }
 
   }
@@ -85,9 +85,9 @@ object ShowInScene extends LowPriorityImplicits {
   implicit object ShowInScenePointCloudFromIndexedSeq extends ShowInScene[IndexedSeq[Point[_3D]]] {
     override type View = PointCloudView
 
-    override def showInScene(pointCloud: IndexedSeq[Point[_3D]], name: String, group: Group, frame: ScalismoFrame): PointCloudView = {
+    override def showInScene(pointCloud: IndexedSeq[Point[_3D]], name: String, group: Group): PointCloudView = {
       val groupNode = group.peer
-      PointCloudView(groupNode.pointClouds.add(pointCloud, name), frame)
+      PointCloudView(groupNode.pointClouds.add(pointCloud, name))
     }
 
   }
@@ -95,44 +95,44 @@ object ShowInScene extends LowPriorityImplicits {
   implicit object ShowInScenePointCloudFromDomain extends ShowInScene[UnstructuredPointsDomain[_3D]] {
     override type View = PointCloudView
 
-    override def showInScene(domain: UnstructuredPointsDomain[_3D], name: String, group: Group, frame: ScalismoFrame): PointCloudView = {
-      ShowInScenePointCloudFromIndexedSeq.showInScene(domain.pointSequence, name, group, frame)
+    override def showInScene(domain: UnstructuredPointsDomain[_3D], name: String, group: Group): PointCloudView = {
+      ShowInScenePointCloudFromIndexedSeq.showInScene(domain.pointSequence, name, group)
     }
   }
 
   implicit def ShowScalarField[S: Scalar: ClassTag] = new ShowInScene[ScalarMeshField[S]] {
     override type View = ScalarMeshFieldView
 
-    override def showInScene(scalarMeshField: ScalarMeshField[S], name: String, group: Group, frame: ScalismoFrame): ScalarMeshFieldView = {
+    override def showInScene(scalarMeshField: ScalarMeshField[S], name: String, group: Group): ScalarMeshFieldView = {
       val scalarConv = implicitly[Scalar[S]]
       val smfAsFloat = scalarMeshField.copy(data = scalarMeshField.data.map[Float](x => scalarConv.toFloat(x)))
-      ScalarMeshFieldView(group.peer.scalarMeshFields.add(smfAsFloat, name), frame)
+      ScalarMeshFieldView(group.peer.scalarMeshFields.add(smfAsFloat, name))
     }
   }
 
   implicit object ShowInSceneDiscreteFieldOfVectors extends ShowInScene[DiscreteField[_3D, Vector[_3D]]] {
     override type View = VectorFieldView
 
-    override def showInScene(df: DiscreteField[_3D, Vector[_3D]], name: String, group: Group, frame: ScalismoFrame): VectorFieldView = {
-      VectorFieldView(group.peer.vectorFields.add(df, name), frame)
+    override def showInScene(df: DiscreteField[_3D, Vector[_3D]], name: String, group: Group): VectorFieldView = {
+      VectorFieldView(group.peer.vectorFields.add(df, name))
     }
   }
 
   implicit def ShowImage[S: Scalar: ClassTag] = new ShowInScene[DiscreteScalarImage[_3D, S]] {
     override type View = ImageView
 
-    override def showInScene(image: DiscreteScalarImage[_3D, S], name: String, group: Group, frame: ScalismoFrame): ImageView = {
+    override def showInScene(image: DiscreteScalarImage[_3D, S], name: String, group: Group): ImageView = {
       val scalarConv = implicitly[Scalar[S]]
       val floatImage = image.map(x => scalarConv.toFloat(x))
-      ImageView(group.peer.images.add(floatImage, name), frame)
+      ImageView(group.peer.images.add(floatImage, name))
     }
   }
 
   implicit object ShowInSceneLandmark extends ShowInScene[Landmark[_3D]] {
     override type View = LandmarkView
 
-    override def showInScene(lm: Landmark[_3D], name: String, group: Group, frame: ScalismoFrame): LandmarkView = {
-      LandmarkView(group.peer.landmarks.add(lm), frame)
+    override def showInScene(lm: Landmark[_3D], name: String, group: Group): LandmarkView = {
+      LandmarkView(group.peer.landmarks.add(lm))
     }
 
   }
@@ -140,9 +140,9 @@ object ShowInScene extends LowPriorityImplicits {
   implicit object ShowInSceneLandmarks extends ShowInScene[Seq[Landmark[_3D]]] {
     override type View = Seq[LandmarkView]
 
-    override def showInScene(lms: Seq[Landmark[_3D]], name: String, group: Group, frame: ScalismoFrame): Seq[LandmarkView] = {
+    override def showInScene(lms: Seq[Landmark[_3D]], name: String, group: Group): Seq[LandmarkView] = {
       val landmarkViews = for (lm <- lms) yield {
-        LandmarkView(group.peer.landmarks.add(lm), frame)
+        LandmarkView(group.peer.landmarks.add(lm))
       }
       landmarkViews
     }
@@ -152,11 +152,11 @@ object ShowInScene extends LowPriorityImplicits {
   implicit object ShowInSceneStatisticalMeshModel extends ShowInScene[StatisticalMeshModel] {
     type View = StatisticalMeshModelViewControls
 
-    override def showInScene(model: StatisticalMeshModel, name: String, group: Group, frame: ScalismoFrame): View = {
+    override def showInScene(model: StatisticalMeshModel, name: String, group: Group): View = {
 
       val shapeModelTransform = ShapeModelTransformation(PointTransformation.RigidIdentity, DiscreteLowRankGpPointTransformation(model.gp))
-      val smV = CreateShapeModelTransformation.showInScene(shapeModelTransform, name, group, frame)
-      val tmV = ShowInSceneMesh.showInScene(model.referenceMesh, name, group, frame)
+      val smV = CreateShapeModelTransformation.showInScene(shapeModelTransform, name, group)
+      val tmV = ShowInSceneMesh.showInScene(model.referenceMesh, name, group)
       StatisticalMeshModelViewControls(tmV, smV)
 
     }
@@ -165,45 +165,45 @@ object ShowInScene extends LowPriorityImplicits {
   implicit object ShowInSceneTransformationGlyph extends ShowInScene[TransformationGlyph] {
     override type View = VectorFieldView
 
-    override def showInScene(transformationGlyph: TransformationGlyph, name: String, group: Group, frame: ScalismoFrame): ShowInSceneTransformationGlyph.View = {
-      VectorFieldView(group.peer.vectorFields.addTransformationGlyph(transformationGlyph.points.toIndexedSeq, name), frame)
+    override def showInScene(transformationGlyph: TransformationGlyph, name: String, group: Group): ShowInSceneTransformationGlyph.View = {
+      VectorFieldView(group.peer.vectorFields.addTransformationGlyph(transformationGlyph.points.toIndexedSeq, name))
     }
   }
 
   implicit object CreateRigidTransformation extends ShowInScene[RigidTransformation[_3D]] {
     override type View = RigidTransformationView
 
-    override def showInScene(t: RigidTransformation[_3D], name: String, group: Group, frame: ScalismoFrame): View = {
-      RigidTransformationView(group.peer.genericTransformations.add(t, name), frame)
+    override def showInScene(t: RigidTransformation[_3D], name: String, group: Group): View = {
+      RigidTransformationView(group.peer.genericTransformations.add(t, name))
     }
   }
 
   implicit object CreateLowRankGPTransformation extends ShowInScene[LowRankGaussianProcess[_3D, Vector[_3D]]] {
     override type View = LowRankGPTransformationView
 
-    override def showInScene(gp: LowRankGaussianProcess[_3D, Vector[_3D]], name: String, group: Group, frame: ScalismoFrame): View = {
+    override def showInScene(gp: LowRankGaussianProcess[_3D, Vector[_3D]], name: String, group: Group): View = {
       val gpNode = group.peer.genericTransformations.add(LowRankGpPointTransformation(gp), name)
-      LowRankGPTransformationView(gpNode, frame)
+      LowRankGPTransformationView(gpNode)
     }
   }
 
   implicit object CreateDiscreteLowRankGPTransformation extends ShowInScene[DiscreteLowRankGaussianProcess[_3D, Vector[_3D]]] {
     override type View = DiscreteLowRankGPTransformationView
 
-    override def showInScene(gp: DiscreteLowRankGaussianProcess[_3D, Vector[_3D]], name: String, group: Group, frame: ScalismoFrame): View = {
+    override def showInScene(gp: DiscreteLowRankGaussianProcess[_3D, Vector[_3D]], name: String, group: Group): View = {
       val gpNode = group.peer.genericTransformations.add(DiscreteLowRankGpPointTransformation(gp), name)
-      DiscreteLowRankGPTransformationView(gpNode, frame)
+      DiscreteLowRankGPTransformationView(gpNode)
     }
   }
 
   implicit object CreateShapeModelTransformation extends ShowInScene[ShapeModelTransformation] {
     override type View = ShapeModelTransformationView
 
-    override def showInScene(transform: ShapeModelTransformation, name: String, group: Group, frame: ScalismoFrame): View = {
+    override def showInScene(transform: ShapeModelTransformation, name: String, group: Group): View = {
       val t = for {
         pose <- group.peer.shapeModelTransformations.addPoseTransformation(transform.poseTransformation)
         shape <- group.peer.shapeModelTransformations.addGaussianProcessTransformation(transform.shapeTransformation)
-      } yield ShapeModelTransformationView(group.peer.shapeModelTransformations, frame)
+      } yield ShapeModelTransformationView(group.peer.shapeModelTransformations)
       t.get
     }
   }

--- a/src/main/scala/scalismo/ui/api/SimpleAPI.scala
+++ b/src/main/scala/scalismo/ui/api/SimpleAPI.scala
@@ -25,7 +25,7 @@ trait SimpleAPI {
 
   def show[A](group: Group, a: A, name: String)(implicit showInScene: ShowInScene[A]): showInScene.View
 
-  def visibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]): Unit
+  def setVisibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]): Unit
 
   def addTransformation[T](g: Group, t: T, name: String)(implicit showInScene: ShowInScene[T]): showInScene.View
 

--- a/src/main/scala/scalismo/ui/api/SimpleAPI.scala
+++ b/src/main/scala/scalismo/ui/api/SimpleAPI.scala
@@ -17,89 +17,33 @@
 
 package scalismo.ui.api
 
-import scalismo.geometry._3D
-import scalismo.registration.RigidTransformation
-import scalismo.ui.model.SceneNode.event.{ ChildAdded, ChildRemoved }
-import scalismo.ui.model._
-import scalismo.ui.view.ScalismoFrame
-
 trait SimpleAPI {
 
-  protected[api] def scene: Scene
+  def createGroup(groupName: String): Group
 
-  protected[api] val frame: ScalismoFrame
+  def show[A](a: A, name: String)(implicit showInScene: ShowInScene[A]): showInScene.View
 
-  def createGroup(groupName: String): Group = Group(scene.groups.add(groupName), frame)
+  def show[A](group: Group, a: A, name: String)(implicit showInScene: ShowInScene[A]): showInScene.View
 
-  def show[A](a: A, name: String)(implicit showInScene: ShowInScene[A]): showInScene.View = showInScene.showInScene(a, name, defaultGroup, frame)
+  def visibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]): Unit
 
-  def show[A](group: Group, a: A, name: String)(implicit showInScene: ShowInScene[A]): showInScene.View = showInScene.showInScene(a, name, group, frame)
+  def addTransformation[T](g: Group, t: T, name: String)(implicit showInScene: ShowInScene[T]): showInScene.View
 
-  def addTransformation[T](g: Group, t: T, name: String)(implicit showInScene: ShowInScene[T]): showInScene.View = {
-    showInScene.showInScene(t, name, g, frame)
-  }
+  def filter[V <: ObjectView: FindInScene](pred: V => Boolean): Seq[V]
 
-  def filter[V <: ObjectView: FindInScene](pred: V => Boolean): Seq[V] = {
-    filterSceneNodes[V](scene, pred)
-  }
+  def filter[V <: ObjectView: FindInScene](group: Group, pred: V => Boolean): Seq[V]
 
-  def filter[V <: ObjectView: FindInScene](group: Group, pred: V => Boolean): Seq[V] = {
-    filterSceneNodes[V](group.peer, pred)
-  }
+  def find[V <: ObjectView: FindInScene](pred: V => Boolean): Option[V]
 
-  def find[V <: ObjectView: FindInScene](pred: V => Boolean): Option[V] =
-    filter[V](pred).headOption
+  def find[V <: ObjectView: FindInScene](group: Group, pred: V => Boolean): Option[V]
 
-  def find[V <: ObjectView: FindInScene](group: Group, pred: V => Boolean): Option[V] =
-    filter[V](group, pred).headOption
+  def onNodeAdded[A <: ObjectView: HandleCallback, R](g: Group, f: A => R): Unit
 
-  def onNodeAdded[A <: ObjectView: HandleCallback, R](g: Group, f: A => R): Unit = {
-    HandleCallback[A].registerOnAdd(g, f, frame)
-  }
+  def onNodeRemoved[A <: ObjectView: HandleCallback, R](g: Group, f: A => R): Unit
 
-  def onNodeRemoved[A <: ObjectView: HandleCallback, R](g: Group, f: A => R): Unit = {
-    HandleCallback[A].registerOnRemove(g, f, frame)
-  }
+  def onGroupAdded[R](f: Group => R): Unit
 
-  def onGroupAdded[R](f: Group => R): Unit = {
-    scene.listenTo(scene.groups)
-
-    scene.reactions += {
-      case ChildAdded(collection, newNode: GroupNode) =>
-        val gv = Group(newNode, frame)
-        f(gv)
-    }
-  }
-
-  def onGroupRemoved[R](f: Group => R): Unit = {
-    scene.listenTo(scene.groups)
-
-    scene.reactions += {
-      case ChildRemoved(collection, newNode: GroupNode) =>
-        val gv = Group(newNode, frame)
-        f(gv)
-    }
-  }
-
-  private def defaultGroup: Group = {
-    val groupNode = scene.groups.find(g => g.name == "group")
-      .getOrElse(scene.groups.add("group"))
-    Group(groupNode, frame)
-  }
-
-  private def filterSceneNodes[V <: ObjectView: FindInScene](node: SceneNode, pred: V => Boolean): Seq[V] = {
-
-    val resFromSubNodes = node.children.flatMap(child => filterSceneNodes(child, pred))
-
-    val find = FindInScene[V]
-
-    val head = find.createView(node, frame) match {
-      case Some(v) => if (pred(v)) Seq[V](v) else Seq[V]()
-      case None => Seq[V]()
-    }
-
-    head ++ resFromSubNodes
-  }
+  def onGroupRemoved[R](f: Group => R): Unit
 
 }
 

--- a/src/main/scala/scalismo/ui/api/SimpleAPIDefaultImpl.scala
+++ b/src/main/scala/scalismo/ui/api/SimpleAPIDefaultImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016  University of Basel, Graphics and Vision Research Group
+ * Copyright (C) 2016  University of Basel, Graphics and Vision Research Group 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/scala/scalismo/ui/api/SimpleAPIDefaultImpl.scala
+++ b/src/main/scala/scalismo/ui/api/SimpleAPIDefaultImpl.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2016  University of Basel, Graphics and Vision Research Group
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scalismo.ui.api
+
+import scalismo.ui.model.{ GroupNode, Scene, SceneNode }
+import scalismo.ui.model.SceneNode.event.{ ChildAdded, ChildRemoved }
+
+trait SimpleAPIDefaultImpl {
+  self: SimpleAPI =>
+
+  protected[api] def scene: Scene
+
+  override def createGroup(groupName: String): Group = Group(scene.groups.add(groupName))
+
+  override def show[A](a: A, name: String)(implicit showInScene: ShowInScene[A]): showInScene.View = showInScene.showInScene(a, name, defaultGroup)
+
+  override def show[A](group: Group, a: A, name: String)(implicit showInScene: ShowInScene[A]): showInScene.View = showInScene.showInScene(a, name, group)
+
+  override def addTransformation[T](g: Group, t: T, name: String)(implicit showInScene: ShowInScene[T]): showInScene.View = {
+    showInScene.showInScene(t, name, g)
+  }
+
+  override def filter[V <: ObjectView: FindInScene](pred: V => Boolean): Seq[V] = {
+    filterSceneNodes[V](scene, pred)
+  }
+
+  override def filter[V <: ObjectView: FindInScene](group: Group, pred: V => Boolean): Seq[V] = {
+    filterSceneNodes[V](group.peer, pred)
+  }
+
+  override def find[V <: ObjectView: FindInScene](pred: V => Boolean): Option[V] =
+    filter[V](pred).headOption
+
+  override def find[V <: ObjectView: FindInScene](group: Group, pred: V => Boolean): Option[V] =
+    filter[V](group, pred).headOption
+
+  override def onNodeAdded[A <: ObjectView: HandleCallback, R](g: Group, f: A => R): Unit = {
+    HandleCallback[A].registerOnAdd(g, f)
+  }
+
+  override def onNodeRemoved[A <: ObjectView: HandleCallback, R](g: Group, f: A => R): Unit = {
+    HandleCallback[A].registerOnRemove(g, f)
+  }
+
+  override def onGroupAdded[R](f: Group => R): Unit = {
+    scene.listenTo(scene.groups)
+
+    scene.reactions += {
+      case ChildAdded(collection, newNode: GroupNode) =>
+        val gv = Group(newNode)
+        f(gv)
+    }
+  }
+
+  override def onGroupRemoved[R](f: Group => R): Unit = {
+    scene.listenTo(scene.groups)
+
+    scene.reactions += {
+      case ChildRemoved(collection, newNode: GroupNode) =>
+        val gv = Group(newNode)
+        f(gv)
+    }
+  }
+
+  private def defaultGroup: Group = {
+    val groupNode = scene.groups.find(g => g.name == "group")
+      .getOrElse(scene.groups.add("group"))
+    Group(groupNode)
+  }
+
+  private def filterSceneNodes[V <: ObjectView: FindInScene](node: SceneNode, pred: V => Boolean): Seq[V] = {
+
+    val resFromSubNodes = node.children.flatMap(child => filterSceneNodes(child, pred))
+
+    val find = FindInScene[V]
+
+    val head = find.createView(node) match {
+      case Some(v) => if (pred(v)) Seq[V](v) else Seq[V]()
+      case None => Seq[V]()
+    }
+
+    head ++ resFromSubNodes
+  }
+
+}

--- a/src/main/scala/scalismo/ui/api/SimpleVisibility.scala
+++ b/src/main/scala/scalismo/ui/api/SimpleVisibility.scala
@@ -16,7 +16,6 @@
  */
 
 package scalismo.ui.api
-import scalismo.ui.model.capabilities.RenderableSceneNode
 
 /**
  * Trait to be mixed with ObjectView instances in order to provide visibility changing functionality
@@ -62,34 +61,4 @@ object Viewport {
   val _3dOnly: Seq[Viewport] = Seq(_3DMain, _3DRight, _3DLeft)
   val _3dLeft: Seq[Viewport] = Seq(_3DLeft)
   val _3dRight: Seq[Viewport] = Seq(_3DRight)
-}
-
-trait SimpleVisibility {
-  self: ObjectView =>
-
-  private def setVisible(isVisible: Boolean, viewportName: String): Unit = {
-    self.frame.perspective.viewports.filter(_.name == viewportName).headOption.foreach { viewPort =>
-      val visib = self.frame.sceneControl.nodeVisibility
-      visib.setVisibility(peer.asInstanceOf[RenderableSceneNode], viewPort, isVisible)
-    }
-  }
-
-  // mainly needed to be able to have the assignment operator
-  def visible: Seq[Viewport] = {
-    val visib = self.frame.sceneControl.nodeVisibility
-    val visibleViewPortNames = self.frame.perspective.viewports.filter(vp => visib.isVisible(peer.asInstanceOf[RenderableSceneNode], vp)).map(_.name)
-    Viewport.all.filter(p => visibleViewPortNames.contains(p.name))
-  }
-
-  /**
-   * Sets the node visible to all views in the config, and invisible in others
-   */
-  def visible_=(visibleViewports: Seq[Viewport]) = {
-    visibleViewports.foreach(v => setVisible(true, v.name))
-
-    //set invisible in other viewports
-    val viewsNotInConfig = self.frame.perspective.viewports.filterNot(v => visibleViewports.exists(_.name == v.name))
-    viewsNotInConfig.foreach(v => setVisible(false, v.name))
-  }
-
 }

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -38,12 +38,10 @@ sealed trait ObjectView {
 
   protected[api] def peer: PeerType
 
-  protected[api] val frame: ScalismoFrame
-
   def name: String = peer.name
 
   def inGroup: Group = {
-    Group(findBelongingGroup(peer), frame)
+    Group(findBelongingGroup(peer))
   }
 
   def remove(): Unit = peer.remove()
@@ -56,13 +54,12 @@ sealed trait ObjectView {
 
 object ObjectView {
   implicit object FindInSceneObjectView extends FindInScene[ObjectView] {
-    override def createView(s: SceneNode, _frame: ScalismoFrame): Option[ObjectView] = {
+    override def createView(s: SceneNode): Option[ObjectView] = {
 
       s match {
         case node: GroupNode => None // we ignore all group nodes, as they are not real objects
         case node: SceneNode with Removeable => {
           val ov = new ObjectView {
-            override val frame = _frame
             override type PeerType = SceneNode with Removeable
 
             override protected[api] def peer = node
@@ -75,7 +72,7 @@ object ObjectView {
   }
 }
 
-case class PointCloudView private[ui] (override protected[api] val peer: PointCloudNode, frame: ScalismoFrame) extends ObjectView with SimpleVisibility {
+case class PointCloudView private[ui] (override protected[api] val peer: PointCloudNode) extends ObjectView {
 
   type PeerType = PointCloudNode
 
@@ -105,9 +102,9 @@ case class PointCloudView private[ui] (override protected[api] val peer: PointCl
 object PointCloudView {
 
   implicit object FindInScenePointCloud extends FindInScene[PointCloudView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[PointCloudView] = {
+    override def createView(s: SceneNode): Option[PointCloudView] = {
       s match {
-        case node: PointCloudNode => Some(PointCloudView(node, frame))
+        case node: PointCloudNode => Some(PointCloudView(node))
         case _ => None
       }
     }
@@ -115,27 +112,27 @@ object PointCloudView {
 
   implicit def callbackPointCloudView = new HandleCallback[PointCloudView] {
 
-    override def registerOnAdd[R](g: Group, f: PointCloudView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: PointCloudView => R): Unit = {
       g.peer.listenTo(g.peer.pointClouds)
       g.peer.reactions += {
         case ChildAdded(collection, newNode: PointCloudNode) =>
-          val tmv = PointCloudView(newNode, frame)
+          val tmv = PointCloudView(newNode)
           f(tmv)
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: PointCloudView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: PointCloudView => R): Unit = {
       g.peer.listenTo(g.peer.pointClouds)
       g.peer.reactions += {
         case ChildRemoved(collection, removedNode: PointCloudNode) =>
-          val tmv = PointCloudView(removedNode, frame)
+          val tmv = PointCloudView(removedNode)
           f(tmv)
       }
     }
   }
 }
 
-case class TriangleMeshView private[ui] (override protected[api] val peer: TriangleMeshNode, frame: ScalismoFrame) extends ObjectView with SimpleVisibility {
+case class TriangleMeshView private[ui] (override protected[api] val peer: TriangleMeshNode) extends ObjectView {
   type PeerType = TriangleMeshNode
 
   def color = peer.color.value
@@ -164,9 +161,9 @@ case class TriangleMeshView private[ui] (override protected[api] val peer: Trian
 object TriangleMeshView {
 
   implicit object FindInSceneTriangleMeshView$ extends FindInScene[TriangleMeshView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[TriangleMeshView] = {
+    override def createView(s: SceneNode): Option[TriangleMeshView] = {
       s match {
-        case peer: TriangleMeshNode => Some(TriangleMeshView(peer, frame))
+        case peer: TriangleMeshNode => Some(TriangleMeshView(peer))
         case _ => None
       }
     }
@@ -174,20 +171,20 @@ object TriangleMeshView {
 
   implicit object callbacksTriangleMeshView extends HandleCallback[TriangleMeshView] {
 
-    override def registerOnAdd[R](g: Group, f: TriangleMeshView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: TriangleMeshView => R): Unit = {
       g.peer.listenTo(g.peer.triangleMeshes)
       g.peer.reactions += {
         case ChildAdded(collection, newNode: TriangleMeshNode) =>
-          val tmv = TriangleMeshView(newNode, frame)
+          val tmv = TriangleMeshView(newNode)
           f(tmv)
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: TriangleMeshView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: TriangleMeshView => R): Unit = {
       g.peer.listenTo(g.peer.triangleMeshes)
       g.peer.reactions += {
         case ChildRemoved(collection, removedNode: TriangleMeshNode) =>
-          val tmv = TriangleMeshView(removedNode, frame)
+          val tmv = TriangleMeshView(removedNode)
           f(tmv)
       }
     }
@@ -195,7 +192,7 @@ object TriangleMeshView {
   }
 }
 
-case class LineMeshView private[ui] (override protected[api] val peer: LineMeshNode, frame: ScalismoFrame) extends ObjectView with SimpleVisibility {
+case class LineMeshView private[ui] (override protected[api] val peer: LineMeshNode) extends ObjectView {
 
   type PeerType = LineMeshNode
 
@@ -224,9 +221,9 @@ case class LineMeshView private[ui] (override protected[api] val peer: LineMeshN
 object LineMeshView {
 
   implicit object FindInSceneLineMeshView extends FindInScene[LineMeshView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[LineMeshView] = {
+    override def createView(s: SceneNode): Option[LineMeshView] = {
       s match {
-        case peer: LineMeshNode => Some(LineMeshView(peer, frame))
+        case peer: LineMeshNode => Some(LineMeshView(peer))
         case _ => None
       }
     }
@@ -234,20 +231,20 @@ object LineMeshView {
 
   implicit object callbackLineMeshView extends HandleCallback[LineMeshView] {
 
-    override def registerOnAdd[R](g: Group, f: LineMeshView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: LineMeshView => R): Unit = {
       g.peer.listenTo(g.peer.lineMeshes)
       g.peer.reactions += {
         case ChildAdded(collection, newNode: LineMeshNode) =>
-          val lmv = LineMeshView(newNode, frame)
+          val lmv = LineMeshView(newNode)
           f(lmv)
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: LineMeshView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: LineMeshView => R): Unit = {
       g.peer.listenTo(g.peer.lineMeshes)
       g.peer.reactions += {
         case ChildRemoved(collection, removedNode: LineMeshNode) =>
-          val lmv = LineMeshView(removedNode, frame)
+          val lmv = LineMeshView(removedNode)
           f(lmv)
       }
     }
@@ -255,7 +252,7 @@ object LineMeshView {
   }
 }
 
-case class LandmarkView private[ui] (override protected[api] val peer: LandmarkNode, frame: ScalismoFrame) extends ObjectView with SimpleVisibility {
+case class LandmarkView private[ui] (override protected[api] val peer: LandmarkNode) extends ObjectView {
 
   type PeerType = LandmarkNode
 
@@ -279,9 +276,9 @@ case class LandmarkView private[ui] (override protected[api] val peer: LandmarkN
 object LandmarkView {
 
   implicit object FindInSceneLandmarkView$ extends FindInScene[LandmarkView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[LandmarkView] = {
+    override def createView(s: SceneNode): Option[LandmarkView] = {
       s match {
-        case peer: LandmarkNode => Some(LandmarkView(peer, frame))
+        case peer: LandmarkNode => Some(LandmarkView(peer))
         case _ => None
       }
     }
@@ -289,20 +286,20 @@ object LandmarkView {
 
   implicit object CallbackLandmarkView extends HandleCallback[LandmarkView] {
 
-    override def registerOnAdd[R](g: Group, f: LandmarkView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: LandmarkView => R): Unit = {
       g.peer.listenTo(g.peer.landmarks)
       g.peer.reactions += {
         case ChildAdded(collection, newNode: LandmarkNode) =>
-          val tmv = LandmarkView(newNode, frame)
+          val tmv = LandmarkView(newNode)
           f(tmv)
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: LandmarkView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: LandmarkView => R): Unit = {
       g.peer.listenTo(g.peer.landmarks)
       g.peer.reactions += {
         case ChildRemoved(collection, removedNode: LandmarkNode) =>
-          val tmv = LandmarkView(removedNode, frame)
+          val tmv = LandmarkView(removedNode)
           f(tmv)
       }
     }
@@ -310,7 +307,7 @@ object LandmarkView {
 
 }
 
-case class ScalarMeshFieldView private[ui] (override protected[api] val peer: ScalarMeshFieldNode, frame: ScalismoFrame) extends ObjectView with SimpleVisibility {
+case class ScalarMeshFieldView private[ui] (override protected[api] val peer: ScalarMeshFieldNode) extends ObjectView {
   type PeerType = ScalarMeshFieldNode
 
   def scalarRange: ScalarRange = peer.scalarRange.value
@@ -338,9 +335,9 @@ case class ScalarMeshFieldView private[ui] (override protected[api] val peer: Sc
 object ScalarMeshFieldView {
 
   implicit object FindInSceneScalarMeshField extends FindInScene[ScalarMeshFieldView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[ScalarMeshFieldView] = {
+    override def createView(s: SceneNode): Option[ScalarMeshFieldView] = {
       s match {
-        case node: ScalarMeshFieldNode => Some(ScalarMeshFieldView(node, frame))
+        case node: ScalarMeshFieldNode => Some(ScalarMeshFieldView(node))
         case _ => None
       }
     }
@@ -348,20 +345,20 @@ object ScalarMeshFieldView {
 
   implicit object CallbackScalarMeshFieldView extends HandleCallback[ScalarMeshFieldView] {
 
-    override def registerOnAdd[R](g: Group, f: ScalarMeshFieldView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: ScalarMeshFieldView => R): Unit = {
       g.peer.listenTo(g.peer.scalarMeshFields)
       g.peer.reactions += {
         case ChildAdded(collection, newNode: ScalarMeshFieldNode) =>
-          val tmv = ScalarMeshFieldView(newNode, frame)
+          val tmv = ScalarMeshFieldView(newNode)
           f(tmv)
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: ScalarMeshFieldView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: ScalarMeshFieldView => R): Unit = {
       g.peer.listenTo(g.peer.scalarMeshFields)
       g.peer.reactions += {
         case ChildRemoved(collection, removedNode: ScalarMeshFieldNode) =>
-          val tmv = ScalarMeshFieldView(removedNode, frame)
+          val tmv = ScalarMeshFieldView(removedNode)
           f(tmv)
       }
     }
@@ -369,7 +366,7 @@ object ScalarMeshFieldView {
 
 }
 
-case class ScalarFieldView private[ui] (override protected[api] val peer: ScalarFieldNode, frame: ScalismoFrame) extends ObjectView with SimpleVisibility {
+case class ScalarFieldView private[ui] (override protected[api] val peer: ScalarFieldNode) extends ObjectView {
   type PeerType = ScalarFieldNode
 
   def scalarRange: ScalarRange = peer.scalarRange.value
@@ -398,9 +395,9 @@ case class ScalarFieldView private[ui] (override protected[api] val peer: Scalar
 object ScalarFieldView {
 
   implicit object FindInSceneScalarMeshField extends FindInScene[ScalarFieldView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[ScalarFieldView] = {
+    override def createView(s: SceneNode): Option[ScalarFieldView] = {
       s match {
-        case node: ScalarFieldNode => Some(ScalarFieldView(node, frame))
+        case node: ScalarFieldNode => Some(ScalarFieldView(node))
         case _ => None
       }
     }
@@ -408,20 +405,20 @@ object ScalarFieldView {
 
   implicit object CallbackScalarFieldView extends HandleCallback[ScalarFieldView] {
 
-    override def registerOnAdd[R](g: Group, f: ScalarFieldView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: ScalarFieldView => R): Unit = {
       g.peer.listenTo(g.peer.scalarFields)
       g.peer.reactions += {
         case ChildAdded(collection, newNode: ScalarFieldNode) =>
-          val tmv = ScalarFieldView(newNode, frame)
+          val tmv = ScalarFieldView(newNode)
           f(tmv)
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: ScalarFieldView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: ScalarFieldView => R): Unit = {
       g.peer.listenTo(g.peer.scalarFields)
       g.peer.reactions += {
         case ChildRemoved(collection, removedNode: ScalarFieldNode) =>
-          val tmv = ScalarFieldView(removedNode, frame)
+          val tmv = ScalarFieldView(removedNode)
           f(tmv)
       }
     }
@@ -429,7 +426,7 @@ object ScalarFieldView {
 
 }
 
-case class VectorFieldView private[ui] (override protected[api] val peer: VectorFieldNode, frame: ScalismoFrame) extends ObjectView with SimpleVisibility {
+case class VectorFieldView private[ui] (override protected[api] val peer: VectorFieldNode) extends ObjectView {
   type PeerType = VectorFieldNode
 
   def scalarRange: ScalarRange = peer.scalarRange.value
@@ -450,9 +447,9 @@ case class VectorFieldView private[ui] (override protected[api] val peer: Vector
 object VectorFieldView {
 
   implicit object FindInSceneScalarMeshField extends FindInScene[VectorFieldView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[VectorFieldView] = {
+    override def createView(s: SceneNode): Option[VectorFieldView] = {
       s match {
-        case node: VectorFieldNode => Some(VectorFieldView(node, frame))
+        case node: VectorFieldNode => Some(VectorFieldView(node))
         case _ => None
       }
     }
@@ -460,20 +457,20 @@ object VectorFieldView {
 
   implicit object CallbackVectorFieldView extends HandleCallback[VectorFieldView] {
 
-    override def registerOnAdd[R](g: Group, f: VectorFieldView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: VectorFieldView => R): Unit = {
       g.peer.listenTo(g.peer.vectorFields)
       g.peer.reactions += {
         case ChildAdded(collection, newNode: VectorFieldNode) =>
-          val tmv = VectorFieldView(newNode, frame)
+          val tmv = VectorFieldView(newNode)
           f(tmv)
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: VectorFieldView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: VectorFieldView => R): Unit = {
       g.peer.listenTo(g.peer.vectorFields)
       g.peer.reactions += {
         case ChildRemoved(collection, removedNode: VectorFieldNode) =>
-          val tmv = VectorFieldView(removedNode, frame)
+          val tmv = VectorFieldView(removedNode)
           f(tmv)
       }
     }
@@ -481,7 +478,7 @@ object VectorFieldView {
 
 }
 
-case class ImageView private[ui] (override protected[api] val peer: ImageNode, frame: ScalismoFrame) extends ObjectView with SimpleVisibility {
+case class ImageView private[ui] (override protected[api] val peer: ImageNode) extends ObjectView {
   type PeerType = ImageNode
 
   def opacity = peer.opacity.value
@@ -506,9 +503,9 @@ case class ImageView private[ui] (override protected[api] val peer: ImageNode, f
 object ImageView {
 
   implicit object FindImage extends FindInScene[ImageView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[ImageView] = {
+    override def createView(s: SceneNode): Option[ImageView] = {
       s match {
-        case imageNode: ImageNode => Some(ImageView(imageNode, frame))
+        case imageNode: ImageNode => Some(ImageView(imageNode))
         case _ => None
       }
     }
@@ -516,20 +513,20 @@ object ImageView {
 
   implicit object CallbackLandmarkView extends HandleCallback[ImageView] {
 
-    override def registerOnAdd[R](g: Group, f: ImageView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: ImageView => R): Unit = {
       g.peer.listenTo(g.peer.images)
       g.peer.reactions += {
         case ChildAdded(collection, newNode: ImageNode) =>
-          val imv = ImageView(newNode, frame)
+          val imv = ImageView(newNode)
           f(imv)
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: ImageView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: ImageView => R): Unit = {
       g.peer.listenTo(g.peer.images)
       g.peer.reactions += {
         case ChildRemoved(collection, removedNode: ImageNode) =>
-          val tmv = ImageView(removedNode, frame)
+          val tmv = ImageView(removedNode)
           f(tmv)
       }
     }
@@ -540,7 +537,7 @@ object ImageView {
 // Note this class does not extend Object view, as there is not really a corresponding node to this concept
 case class StatisticalMeshModelViewControls private[ui] (val meshView: TriangleMeshView, val shapeModelTransformationView: ShapeModelTransformationView)
 
-case class Group(override protected[api] val peer: GroupNode, val frame: ScalismoFrame) extends ObjectView {
+case class Group(override protected[api] val peer: GroupNode) extends ObjectView {
 
   def hidden_=(b: Boolean): Unit = {
     peer.isGhost = b
@@ -554,9 +551,9 @@ case class Group(override protected[api] val peer: GroupNode, val frame: Scalism
 object Group {
 
   implicit object FindInSceneGroup$ extends FindInScene[Group] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[Group] = {
+    override def createView(s: SceneNode): Option[Group] = {
       s match {
-        case node: GroupNode => Some(Group(node, frame))
+        case node: GroupNode => Some(Group(node))
         case _ => None
       }
     }
@@ -564,7 +561,7 @@ object Group {
 
 }
 
-case class TransformationView private[ui] (override protected[api] val peer: TransformationNode[Point[_3D] => Point[_3D]], frame: ScalismoFrame) extends ObjectView {
+case class TransformationView private[ui] (override protected[api] val peer: TransformationNode[Point[_3D] => Point[_3D]]) extends ObjectView {
   def transformation: Point[_3D] => Point[_3D] = peer.transformation
 
   def transformation_=(t: Point[_3D] => Point[_3D]): Unit = {
@@ -578,13 +575,13 @@ case class TransformationView private[ui] (override protected[api] val peer: Tra
 object TransformationView {
 
   implicit object FindInSceneGenericTransformation$ extends FindInScene[TransformationView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[TransformationView] = {
+    override def createView(s: SceneNode): Option[TransformationView] = {
 
       type PointToPointTransformation[D <: Dim] = Point[D] => Point[D]
       // here we need a two step process due to type erasure to find the right type.
       s match {
         case value: TransformationNode[_] if value.transformation.isInstanceOf[PointToPointTransformation[_]] =>
-          Some(TransformationView(s.asInstanceOf[TransformationNode[PointToPointTransformation[_3D]]], frame))
+          Some(TransformationView(s.asInstanceOf[TransformationNode[PointToPointTransformation[_3D]]]))
         case _ => None
       }
     }
@@ -592,7 +589,7 @@ object TransformationView {
 
 }
 
-case class RigidTransformationView private[ui] (override protected[api] val peer: TransformationNode[RigidTransformation[_3D]], frame: ScalismoFrame) extends ObjectView {
+case class RigidTransformationView private[ui] (override protected[api] val peer: TransformationNode[RigidTransformation[_3D]]) extends ObjectView {
 
   override type PeerType = TransformationNode[RigidTransformation[_3D]]
 
@@ -606,14 +603,14 @@ case class RigidTransformationView private[ui] (override protected[api] val peer
 object RigidTransformationView {
 
   implicit object FindInSceneRigidTransformation$ extends FindInScene[RigidTransformationView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[RigidTransformationView] = {
+    override def createView(s: SceneNode): Option[RigidTransformationView] = {
 
       // here we need a two step process due to type erasure to find the right type.
       s match {
         // filter out Rigid transformations that are part of a StatisticalShapeMoodelTransformation
         case value: ShapeModelTransformationComponentNode[_] if value.transformation.isInstanceOf[RigidTransformation[_]] => None
         case value: TransformationNode[_] if value.transformation.isInstanceOf[RigidTransformation[_]] =>
-          Some(RigidTransformationView(s.asInstanceOf[TransformationNode[RigidTransformation[_3D]]], frame))
+          Some(RigidTransformationView(s.asInstanceOf[TransformationNode[RigidTransformation[_3D]]]))
         case _ => None
       }
     }
@@ -621,25 +618,25 @@ object RigidTransformationView {
 
   implicit object CallbackRigidTransformation extends HandleCallback[RigidTransformationView] {
 
-    override def registerOnAdd[R](g: Group, f: RigidTransformationView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: RigidTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.genericTransformations)
       g.peer.reactions += {
         case ChildAdded(collection, newNode: TransformationNode[_]) =>
 
           if (newNode.transformation.isInstanceOf[RigidTransformation[_]]) {
-            val tmv = RigidTransformationView(newNode.asInstanceOf[TransformationNode[RigidTransformation[_3D]]], frame)
+            val tmv = RigidTransformationView(newNode.asInstanceOf[TransformationNode[RigidTransformation[_3D]]])
             f(tmv)
           }
 
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: RigidTransformationView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: RigidTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.genericTransformations)
       g.peer.reactions += {
         case ChildRemoved(collection, removedNode: TransformationNode[_]) =>
           if (removedNode.transformation.isInstanceOf[RigidTransformation[_]]) {
-            val tmv = RigidTransformationView(removedNode.asInstanceOf[TransformationNode[RigidTransformation[_3D]]], frame)
+            val tmv = RigidTransformationView(removedNode.asInstanceOf[TransformationNode[RigidTransformation[_3D]]])
             f(tmv)
           }
       }
@@ -648,7 +645,7 @@ object RigidTransformationView {
 
 }
 
-case class DiscreteLowRankGPTransformationView private[ui] (override protected[api] val peer: TransformationNode[DiscreteLowRankGpPointTransformation], frame: ScalismoFrame) extends ObjectView {
+case class DiscreteLowRankGPTransformationView private[ui] (override protected[api] val peer: TransformationNode[DiscreteLowRankGpPointTransformation]) extends ObjectView {
 
   override type PeerType = TransformationNode[DiscreteLowRankGpPointTransformation]
 
@@ -672,14 +669,14 @@ case class DiscreteLowRankGPTransformationView private[ui] (override protected[a
 object DiscreteLowRankGPTransformationView {
 
   implicit object FindInSceneDiscreteGPTransformation$ extends FindInScene[DiscreteLowRankGPTransformationView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[DiscreteLowRankGPTransformationView] = {
+    override def createView(s: SceneNode): Option[DiscreteLowRankGPTransformationView] = {
 
       // here we need a two step process due to type erasure to find the right type.
       s match {
         // filter out Rigid transformations that are part of a StatisticalShapeMoodelTransformation
         case value: ShapeModelTransformationComponentNode[_] if value.transformation.isInstanceOf[DiscreteLowRankGpPointTransformation] => None
         case value: TransformationNode[_] if value.transformation.isInstanceOf[DiscreteLowRankGpPointTransformation] =>
-          Some(DiscreteLowRankGPTransformationView(s.asInstanceOf[TransformationNode[DiscreteLowRankGpPointTransformation]], frame))
+          Some(DiscreteLowRankGPTransformationView(s.asInstanceOf[TransformationNode[DiscreteLowRankGpPointTransformation]]))
         case _ => None
       }
     }
@@ -687,25 +684,25 @@ object DiscreteLowRankGPTransformationView {
 
   implicit object CallbackDiscreteGPTransformation extends HandleCallback[DiscreteLowRankGPTransformationView] {
 
-    override def registerOnAdd[R](g: Group, f: DiscreteLowRankGPTransformationView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: DiscreteLowRankGPTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.genericTransformations)
       g.peer.reactions += {
         case ChildAdded(collection, newNode: TransformationNode[_]) =>
 
           if (newNode.transformation.isInstanceOf[DiscreteLowRankGpPointTransformation]) {
-            val tmv = DiscreteLowRankGPTransformationView(newNode.asInstanceOf[TransformationNode[DiscreteLowRankGpPointTransformation]], frame)
+            val tmv = DiscreteLowRankGPTransformationView(newNode.asInstanceOf[TransformationNode[DiscreteLowRankGpPointTransformation]])
             f(tmv)
           }
 
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: DiscreteLowRankGPTransformationView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: DiscreteLowRankGPTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.genericTransformations)
       g.peer.reactions += {
         case ChildRemoved(collection, removedNode: TransformationNode[_]) =>
           if (removedNode.transformation.isInstanceOf[DiscreteLowRankGpPointTransformation]) {
-            val tmv = DiscreteLowRankGPTransformationView(removedNode.asInstanceOf[TransformationNode[DiscreteLowRankGpPointTransformation]], frame)
+            val tmv = DiscreteLowRankGPTransformationView(removedNode.asInstanceOf[TransformationNode[DiscreteLowRankGpPointTransformation]])
             f(tmv)
           }
       }
@@ -714,7 +711,7 @@ object DiscreteLowRankGPTransformationView {
 
 }
 
-case class LowRankGPTransformationView private[ui] (override protected[api] val peer: TransformationNode[LowRankGpPointTransformation], frame: ScalismoFrame) extends ObjectView {
+case class LowRankGPTransformationView private[ui] (override protected[api] val peer: TransformationNode[LowRankGpPointTransformation]) extends ObjectView {
 
   override type PeerType = TransformationNode[LowRankGpPointTransformation]
 
@@ -735,16 +732,16 @@ object ShapeModelTransformation {
   }
 }
 
-case class ShapeModelTransformationView private[ui] (override protected[api] val peer: ShapeModelTransformationsNode, frame: ScalismoFrame) extends ObjectView {
+case class ShapeModelTransformationView private[ui] (override protected[api] val peer: ShapeModelTransformationsNode) extends ObjectView {
 
   override type PeerType = ShapeModelTransformationsNode
 
-  def shapeTransformationView = peer.gaussianProcessTransformation.map(DiscreteLowRankGPTransformationView(_, frame)) match {
+  def shapeTransformationView = peer.gaussianProcessTransformation.map(DiscreteLowRankGPTransformationView(_)) match {
     case Some(sv) => sv
     case None => throw new Exception("There is no Gaussian Process (shape) transformation associated with this ShapeModelTransformationView.")
   }
 
-  def poseTransformationView = peer.poseTransformation.map(RigidTransformationView(_, frame)) match {
+  def poseTransformationView = peer.poseTransformation.map(RigidTransformationView(_)) match {
     case Some(sv) => sv
     case None => throw new Exception("There is no rigid (pose) transformation associated with this ShapeModelTransformationView.")
   }
@@ -757,10 +754,10 @@ case class ShapeModelTransformationView private[ui] (override protected[api] val
 object ShapeModelTransformationView {
 
   implicit object FindInSceneShapeModelTransformation extends FindInScene[ShapeModelTransformationView] {
-    override def createView(s: SceneNode, frame: ScalismoFrame): Option[ShapeModelTransformationView] = {
+    override def createView(s: SceneNode): Option[ShapeModelTransformationView] = {
 
       s match {
-        case value: ShapeModelTransformationsNode => Some(ShapeModelTransformationView(value, frame))
+        case value: ShapeModelTransformationsNode => Some(ShapeModelTransformationView(value))
         case _ => None
       }
     }
@@ -768,17 +765,17 @@ object ShapeModelTransformationView {
 
   implicit object CallbackShapeModelTransformation extends HandleCallback[ShapeModelTransformationView] {
 
-    override def registerOnAdd[R](g: Group, f: ShapeModelTransformationView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnAdd[R](g: Group, f: ShapeModelTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.shapeModelTransformations)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: TransformationNode[_]) => f(ShapeModelTransformationView(g.peer.shapeModelTransformations, frame))
+        case ChildAdded(collection, newNode: TransformationNode[_]) => f(ShapeModelTransformationView(g.peer.shapeModelTransformations))
       }
     }
 
-    override def registerOnRemove[R](g: Group, f: ShapeModelTransformationView => R, frame: ScalismoFrame): Unit = {
+    override def registerOnRemove[R](g: Group, f: ShapeModelTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.shapeModelTransformations)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: TransformationNode[_]) => f(ShapeModelTransformationView(g.peer.shapeModelTransformations, frame))
+        case ChildRemoved(collection, removedNode: TransformationNode[_]) => f(ShapeModelTransformationView(g.peer.shapeModelTransformations))
       }
     }
   }


### PR DESCRIPTION
This PR provides a solution to issue #8. It separates the simple api from its implementation in the ```ScalismoUI``` object. Further, a second implementation, the ```ScalismoNullUI``` is provided, which does not do any visualization. 

This makes it possible to switch off visualization by simply changing the ```ScalismoUI``` object with ```ScalismoNullUI```. No visualization code needs to be commented out anymore. 

A problem in the process was that the method ```visible``` of the ViewObjects required that a frame was present, because the visibility can only be set given a corresponding frame. Therefore this method was removed and replaced with a new API method called ```setVisible```. To make an object visible, the following method  is used:
```
ui.setVisibility(object, viewports)
```
 
I am not 100 % sure if this method really should be part of the API, or if it should only be part of the ```ScalismoUI``` object. If it is part of the API, it is assumed that any possible implementation of the API has a way to deal with the same viewports. Not making this method part of the API, but only the ```ScalismoUI``` implementation would mean that calls in a program that manipulate the visibility would need to be specially handled when switching from ```ScalismoUI``` to ```ScalismoNullUI```. 

