### PR TITLE
Added possibility to load shape models from h5 files with model catalog (Fixes #11)

### DIFF
--- a/src/main/scala/scalismo/ui/view/action/popup/LoadStatisticalShapeModelAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/LoadStatisticalShapeModelAction.scala
@@ -18,14 +18,18 @@
 package scalismo.ui.view.action.popup
 
 import java.io.File
+import javax.swing.text.TableView
 
 import scalismo.io.StatismoIO
+import scalismo.io.StatismoIO.{ CatalogEntry, StatismoModelType }
 import scalismo.ui.model.{ GroupNode, SceneNode }
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.util.{ FileIoMetadata, FileUtil }
 import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.action.LoadAction
 
+import scala.swing.BorderPanel.Position
+import scala.swing.{ Action, Alignment, BorderPanel, BoxPanel, Button, ComboBox, Dialog, FlowPanel, GridPanel, Label, Orientation, Swing, Table, TextArea, TextField }
 import scala.util.{ Failure, Success, Try }
 
 object LoadStatisticalShapeModelAction extends PopupAction.Factory {
@@ -34,18 +38,90 @@ object LoadStatisticalShapeModelAction extends PopupAction.Factory {
   }
 }
 
-class LoadStatisticalShapeModelAction(group: GroupNode)(implicit frame: ScalismoFrame) extends PopupAction(s"Load ${FileIoMetadata.StatisticalShapeModel.description} ...", BundledIcon.Load) {
+class LoadStatisticalShapeModelAction(group: GroupNode)(implicit frame: ScalismoFrame)
+    extends PopupAction(s"Load ${FileIoMetadata.StatisticalShapeModel.description} ...", BundledIcon.Load) {
+
   def load(file: File): Try[Unit] = {
-    StatismoIO.readStatismoMeshModel(file) match {
-      case Failure(ex) => Failure(ex)
-      case Success(model) =>
-        val basename = FileUtil.basename(file)
-        group.addStatisticalMeshModel(model, basename)
-        Success(())
+
+    for {
+      path <- selectPathFromFile(file)
+      model <- StatismoIO.readStatismoMeshModel(file, path)
+    } yield {
+      val basename = FileUtil.basename(file)
+      group.addStatisticalMeshModel(model, basename)
     }
   }
 
   override def apply(): Unit = {
     new LoadAction(load, FileIoMetadata.StatisticalShapeModel).apply()
   }
+
+  private def selectPathFromFile(file: File): Try[String] = {
+
+    StatismoIO.readModelCatalog(file) match {
+
+      case Failure(ex) =>
+        if (ex == StatismoIO.NoCatalogPresentException) {
+          // no catalog, assuming a single contained model
+          Success("/")
+        } else Failure(ex)
+
+      case Success(catalog) =>
+        val entries = catalog.filter(e => e.modelType == StatismoModelType.Polygon_Mesh)
+
+        if (entries.isEmpty) {
+          Failure(new IllegalArgumentException("File does not contain any usable model"))
+        } else if (entries.length == 1) {
+          Success(entries.head.modelPath)
+        } else {
+          val title = "Select shape model to load"
+          val description = "The file contains more that one shape model. Please select the one you wish to load."
+
+          var items = List("Item 1", "Item 2", "Item 3", "Item 4")
+
+          val dialog = new ShapeModelSelectionDialog(entries)
+          dialog.open()
+
+          Success(dialog.path)
+        }
+    }
+  }
+
+  // shows a combobox with the catalog entries
+  private class ShapeModelSelectionDialog(entries: Seq[CatalogEntry]) extends Dialog(frame) {
+
+    private val text1 = new Label("Several models are stored in the h5 file.")
+    text1.horizontalAlignment = Alignment.Left
+    private val text2 = new Label("Please select which one you would like to load.")
+    text2.horizontalAlignment = Alignment.Left
+
+    private val combo = new ComboBox(entries.map(_.name))
+
+    // centers dialog on frame
+    this.peer.setLocationRelativeTo(null)
+
+    title = "Select model"
+    modal = true
+
+    contents = new BoxPanel(Orientation.Vertical) {
+      contents += new GridPanel(3, 1) {
+        contents += text1
+        contents += text2
+        contents += combo
+      }
+      contents += new FlowPanel() {
+        contents += new Button(Action("ok") {
+          close()
+        })
+      }
+    }
+
+    pack()
+
+    // the path entry will always be found, as the user can only select entries from the
+    // same list. Hence .get is justified here.
+    def path = entries.find(_.name == combo.selection.item).get.modelPath
+
+  }
+
 }


### PR DESCRIPTION
Some h5 files, such as the one from the Basel Face Model, do not store the shape model in the root location of the h5 file, but have a separate model catalog that specifies the path in the file where the model is stored. Support for such models was added. If several valid shape models are present, a selection dialog with all shape models is shown to the user. 

