### PR TITLE
Making saving volume images from within the UI possible (#26)

### DIFF
--- a/src/main/scala/scalismo/ui/model/ImageNode.scala
+++ b/src/main/scala/scalismo/ui/model/ImageNode.scala
@@ -49,7 +49,7 @@ class ImagesNode(override val parent: GroupNode) extends SceneNodeCollection[Ima
   }
 }
 
-class ImageNode(override val parent: ImagesNode, val source: DiscreteScalarImage[_3D, Float], initialName: String) extends RenderableSceneNode with Grouped with Renameable with Removeable with HasWindowLevel with HasOpacity {
+class ImageNode(override val parent: ImagesNode, val source: DiscreteScalarImage[_3D, Float], initialName: String) extends RenderableSceneNode with Grouped with Renameable with Saveable with Removeable with HasWindowLevel with HasOpacity {
   name = initialName
 
   val (minimumValue, maximumValue) = {
@@ -62,6 +62,18 @@ class ImageNode(override val parent: ImagesNode, val source: DiscreteScalarImage
       max = Math.max(max, value)
     }
     (min, max)
+  }
+
+  override def saveMetadata: FileIoMetadata = FileIoMetadata.Image
+
+  override def save(file: File): Try[Unit] = {
+    val ext = FileUtil.extension(file)
+    ext match {
+      case "vtk" => ImageIO.writeVTK(source, file)
+      case "nii" => ImageIO.writeNifti(source, file)
+      case _ => Failure(new Exception(s"File $file: unsupported file extension"))
+    }
+
   }
 
   override val windowLevel: WindowLevelProperty = {


### PR DESCRIPTION
This pull request fixes the issue (#26). With these small code changes, a user can pick an image with a RMB click and save it. In the dialog, the image can be saved as either vtk or nifti image. The failure case, providing a filename with a different extension than *.vtk or *.nii results in a failure.