### PR TITLE
Adding group node action setting all childrens visibility

### DIFF
--- a/src/main/scala/scalismo/ui/view/NodesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodesPanel.scala
@@ -18,18 +18,18 @@
 package scalismo.ui.view
 
 import java.awt.event._
+
 import javax.swing.event.{ TreeSelectionEvent, TreeSelectionListener }
 import javax.swing.plaf.basic.BasicTreeUI
 import javax.swing.tree._
 import javax.swing.{ Icon, JPopupMenu, JTree }
-
 import scalismo.ui.model._
 import scalismo.ui.model.capabilities.{ CollapsableView, Removeable }
 import scalismo.ui.model.properties.ColorProperty
 import scalismo.ui.resources.icons.{ BundledIcon, FontIcon, ScalableIcon }
 import scalismo.ui.util.NodeListFilters
 import scalismo.ui.view.NodesPanel.{ SceneNodeCellRenderer, ViewNode }
-import scalismo.ui.view.action.popup.{ PopupAction, PopupActionWithOwnMenu }
+import scalismo.ui.view.action.popup.{ ChildVisibilityAction, PopupAction, PopupActionWithOwnMenu }
 
 import scala.collection.JavaConversions.enumerationAsScalaIterator
 import scala.collection.immutable

--- a/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2016  University of Basel, Graphics and Vision Research Group 
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scalismo.ui.view.action.popup
+
+import java.awt.Color
+import java.awt.event.{ MouseAdapter, MouseEvent }
+
+import javax.swing.{ BorderFactory, Icon, JComponent }
+import scalismo.ui.control.NodeVisibility
+import scalismo.ui.control.NodeVisibility.{ Invisible, PartlyVisible, Visible }
+import scalismo.ui.model.{ GroupNode, SceneNode }
+import scalismo.ui.resources.icons.BundledIcon
+import scalismo.ui.view.{ ScalismoFrame, ViewportPanel }
+
+import scala.swing._
+
+object ChildVisibilityAction extends PopupAction.Factory {
+  override def apply(nodes: List[SceneNode])(implicit frame: ScalismoFrame): List[PopupActionWithOwnMenu] = {
+    val affected = allMatch[GroupNode](nodes)
+    if (affected.isEmpty) {
+      Nil
+    } else {
+      List(new ChildVisibilityAction(affected))
+    }
+  }
+}
+
+class ChildVisibilityAction(nodes: List[GroupNode])(implicit frame: ScalismoFrame) extends PopupActionWithOwnMenu {
+  val control = frame.sceneControl.nodeVisibility
+
+  override def menuItem: JComponent = {
+    val viewports = frame.perspective.viewports
+    if (viewports.length > 1) {
+      val menu = new Menu("Childrens's visibility in") {
+        def updateIcon(): Unit = {
+          icon = iconFor(control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), frame.perspective.viewports))
+        }
+
+        listenTo(control)
+
+        reactions += {
+          case NodeVisibility.event.NodeVisibilityChanged(node, viewport) =>
+            if (nodes.contains(node) && viewports.contains(viewport)) {
+              updateIcon()
+              peer.repaint()
+            }
+        }
+
+        peer.add(new ViewportVisibilityItem(viewports, "(all)").peer)
+
+        viewports.foreach { vp =>
+          peer.add(new ViewportVisibilityItem(List(vp), vp.name).peer)
+        }
+        updateIcon()
+      }
+      menu.peer
+
+    } else {
+      new ViewportVisibilityItem(viewports, "Child's visibility").peer
+    }
+  }
+
+  def iconFor(state: NodeVisibility.State): Icon = {
+    val icon = state match {
+      case Visible => BundledIcon.Visible
+      case Invisible => BundledIcon.Invisible
+      case PartlyVisible => BundledIcon.Visible.colored(Color.GRAY)
+    }
+    icon.standardSized()
+  }
+
+  class ViewportVisibilityItem(viewports: List[ViewportPanel], name: String) extends Label(name) {
+    val tb = 2
+    val lr = 12
+
+    def currentState = control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), viewports)
+
+    border = BorderFactory.createEmptyBorder(tb, lr, tb, lr)
+    icon = iconFor(currentState)
+
+    peer.addMouseListener(new MouseAdapter {
+      override def mouseClicked(e: MouseEvent): Unit = {
+        if (e.getButton == MouseEvent.BUTTON1) {
+          val toggle = currentState match {
+            case Visible => false
+            case _ => true
+          }
+          control.setVisibility(nodes.flatMap(_.renderables), viewports, toggle)
+        }
+      }
+    })
+
+    listenTo(control)
+
+    reactions += {
+      case NodeVisibility.event.NodeVisibilityChanged(node, viewport) =>
+        if (nodes.flatMap(_.renderables).contains(node) && viewports.contains(viewport)) {
+          icon = iconFor(currentState)
+          peer.repaint()
+        }
+    }
+  }
+
+}

--- a/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
@@ -49,7 +49,8 @@ class ChildVisibilityAction(nodes: List[GroupNode])(implicit frame: ScalismoFram
     if (viewports.length > 1) {
       val menu = new Menu("Children visible in") {
         def updateIcon(): Unit = {
-          icon = iconFor(control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), frame.perspective.viewports))
+          val state = if (nodes.isEmpty || nodes.flatMap(_.renderables.find(_ => true)).size == 0) Invisible else control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), frame.perspective.viewports)
+          icon = iconFor(state)
         }
 
         listenTo(control)
@@ -89,7 +90,7 @@ class ChildVisibilityAction(nodes: List[GroupNode])(implicit frame: ScalismoFram
     val tb = 2.scaled
     val lr = 12.scaled
 
-    def currentState = control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), viewports)
+    def currentState = if (nodes.isEmpty || nodes.flatMap(_.renderables.find(_ => true)).size == 0) Invisible else control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), viewports)
 
     border = BorderFactory.createEmptyBorder(tb, lr, tb, lr)
     icon = iconFor(currentState)

--- a/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
@@ -26,6 +26,7 @@ import scalismo.ui.control.NodeVisibility.{ Invisible, PartlyVisible, Visible }
 import scalismo.ui.model.{ GroupNode, SceneNode }
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.view.{ ScalismoFrame, ViewportPanel }
+import scalismo.ui.view.util.ScalableUI.implicits._
 
 import scala.swing._
 
@@ -46,7 +47,7 @@ class ChildVisibilityAction(nodes: List[GroupNode])(implicit frame: ScalismoFram
   override def menuItem: JComponent = {
     val viewports = frame.perspective.viewports
     if (viewports.length > 1) {
-      val menu = new Menu("Childrens's visibility in") {
+      val menu = new Menu("Children visible in") {
         def updateIcon(): Unit = {
           icon = iconFor(control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), frame.perspective.viewports))
         }
@@ -71,7 +72,7 @@ class ChildVisibilityAction(nodes: List[GroupNode])(implicit frame: ScalismoFram
       menu.peer
 
     } else {
-      new ViewportVisibilityItem(viewports, "Child's visibility").peer
+      new ViewportVisibilityItem(viewports, "Children visible").peer
     }
   }
 
@@ -85,8 +86,8 @@ class ChildVisibilityAction(nodes: List[GroupNode])(implicit frame: ScalismoFram
   }
 
   class ViewportVisibilityItem(viewports: List[ViewportPanel], name: String) extends Label(name) {
-    val tb = 2
-    val lr = 12
+    val tb = 2.scaled
+    val lr = 12.scaled
 
     def currentState = control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), viewports)
 

--- a/src/main/scala/scalismo/ui/view/action/popup/PopupAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/PopupAction.scala
@@ -37,6 +37,7 @@ object PopupAction {
 
   val BuiltinFactories: List[Factory] = List(
     // the order here also defines the order in the popup menu, so arrange entries as needed
+    ChildVisibilityAction,
     VisibilityAction,
     CenterOnLandmarkAction,
     AddGroupAction,

--- a/src/main/scala/scalismo/ui/view/action/popup/VisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/VisibilityAction.scala
@@ -27,6 +27,7 @@ import scalismo.ui.model.SceneNode
 import scalismo.ui.model.capabilities.RenderableSceneNode
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.view.{ ScalismoFrame, ViewportPanel }
+import scalismo.ui.view.util.ScalableUI.implicits._
 
 import scala.swing._
 
@@ -86,8 +87,8 @@ class VisibilityAction(nodes: List[RenderableSceneNode])(implicit frame: Scalism
   }
 
   class ViewportVisibilityItem(viewports: List[ViewportPanel], name: String) extends Label(name) {
-    val tb = 2
-    val lr = 12
+    val tb = 2.scaled
+    val lr = 12.scaled
 
     def currentState = control.getVisibilityState(nodes, viewports)
 


### PR DESCRIPTION
This PR addresses #28 with a new action for group nodes. This action changes the visibility of all renderable children in a group. The behavior is the same as for renderable objects. This also works for a selection of groups.

A remaining issue will be the simultaneous change of groups and renderable objects visibility at the same time.