### PR TITLE
Code cleanup and modernization

### DIFF
--- a/assembly.sbt
+++ b/assembly.sbt
@@ -10,7 +10,7 @@ mainClass in assembly := Some("scalismo.ui.app.ScalismoViewer")
 
 fork in run := true
 
-mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) => {
+mergeStrategy in assembly ~= { _ => {
   case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
   case PathList("META-INF", s) if s.endsWith(".SF") || s.endsWith(".DSA") || s.endsWith(".RSA") || s.endsWith(".txt") => MergeStrategy.discard
   case _ => MergeStrategy.first

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
 
 
-  val buildScalaVersion = "2.12.6"
+  val buildScalaVersion = "2.12.8"
 
   val buildSettings = Defaults.coreDefaultSettings ++ Seq(
     scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
@@ -18,7 +18,7 @@ object BuildSettings {
     }),
     organization := buildOrganization,
     scalaVersion := buildScalaVersion,
-    crossScalaVersions := Seq("2.11.12", "2.12.6")
+    crossScalaVersions := Seq("2.11.12", "2.12.8")
   ) ++ buildInfoSettings ++ Seq(
     sourceGenerators in Compile += buildInfo,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, BuildInfoKey.action("buildTime") {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,7 +11,7 @@ object BuildSettings {
 
   val buildScalaVersion = "2.12.6"
 
-  val buildSettings = Defaults.defaultSettings ++ Seq(
+  val buildSettings = Defaults.coreDefaultSettings ++ Seq(
     scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2,  11)) =>  Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.6")
       case _ => Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.8")
@@ -20,7 +20,7 @@ object BuildSettings {
     scalaVersion := buildScalaVersion,
     crossScalaVersions := Seq("2.11.12", "2.12.6")
   ) ++ buildInfoSettings ++ Seq(
-    sourceGenerators in Compile <+= buildInfo,
+    sourceGenerators in Compile += buildInfo,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, BuildInfoKey.action("buildTime") {
       new java.text.SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z (z)", java.util.Locale.US).format(new java.util.Date)
     }, BuildInfoKey.action("buildTimestamp") {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.0")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.3.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.10.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.0")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.3.0")
 

--- a/src/main/java/scalismo/ui/view/swing/CustomListCellRenderer.java
+++ b/src/main/java/scalismo/ui/view/swing/CustomListCellRenderer.java
@@ -25,7 +25,7 @@ import java.awt.*;
  * This cannot be directly done in Scala, because it produces some weird type errors, so we
  * resort to an abstract method with a well-defined signature that can be overridden in Scala.
  *
- * @see scalismo.ui.view.StatusBar.StatusMessageCellRenderer for an example.
+ * See <tt>scalismo.ui.view.StatusBar.StatusMessageCellRenderer</tt> for an example.
  */
 public abstract class CustomListCellRenderer extends DefaultListCellRenderer {
     @Override

--- a/src/main/scala/scalismo/ui/api/FindInScene.scala
+++ b/src/main/scala/scalismo/ui/api/FindInScene.scala
@@ -17,8 +17,7 @@
 
 package scalismo.ui.api
 
-import scalismo.ui.model._
-import scalismo.ui.view.ScalismoFrame
+import scalismo.ui.model.SceneNode
 
 /**
  * This typeclass needs to be implemented for a type V (a view) if the user should be

--- a/src/main/scala/scalismo/ui/api/HandleCallback.scala
+++ b/src/main/scala/scalismo/ui/api/HandleCallback.scala
@@ -17,8 +17,6 @@
 
 package scalismo.ui.api
 
-import scalismo.ui.view.ScalismoFrame
-
 /**
  * This typeclass needs to be implemented if callbacks should be allowed for a view V
  */

--- a/src/main/scala/scalismo/ui/api/Interactors.scala
+++ b/src/main/scala/scalismo/ui/api/Interactors.scala
@@ -47,7 +47,7 @@ case class SimplePosteriorLandmarkingInteractor(ui: ScalismoUI, modelGroup: Grou
     val meshView = ui.find[TriangleMeshView](modelGroup, (p: TriangleMeshView) => true).get
     //  val shapeTransformationView = ui.find[DiscreteLowRankGPTransformationView](modelGroup, (p: DiscreteLowRankGPTransformationView) => true).get
 
-    private val previewGroup = Group(ui.frame.scene.groups.add("__preview__", ghost = true))
+    private val previewGroup = Group(ui.frame.scene.groups.add("__preview__", hidden = true))
 
     // we start by copying the shape model transformations of the modelGroup into the previewGroup
     modelGroup.peer.shapeModelTransformations.poseTransformation.map(p => previewGroup.peer.shapeModelTransformations.addPoseTransformation(p.transformation))
@@ -58,7 +58,7 @@ case class SimplePosteriorLandmarkingInteractor(ui: ScalismoUI, modelGroup: Grou
     previewNode.color.value = Color.YELLOW
     previewNode.pickable.value = false
 
-    override val targetUncertaintyGroup = Group(ui.frame.scene.groups.add("__target_preview__", ghost = true)).peer
+    override val targetUncertaintyGroup = Group(ui.frame.scene.groups.add("__target_preview__", hidden = true)).peer
 
     override def sourceGpNode: TransformationNode[DiscreteLowRankGpPointTransformation] = modelGroup.peer.shapeModelTransformations.gaussianProcessTransformation.get
 

--- a/src/main/scala/scalismo/ui/api/Interactors.scala
+++ b/src/main/scala/scalismo/ui/api/Interactors.scala
@@ -28,6 +28,7 @@ import scalismo.ui.view.ScalismoFrame
 
 private[api] sealed trait SimpleInteractor {
   type ConcreteInteractor <: Interactor
+
   def ui: ScalismoUI
 
   protected[api] def peer: ConcreteInteractor

--- a/src/main/scala/scalismo/ui/api/Interactors.scala
+++ b/src/main/scala/scalismo/ui/api/Interactors.scala
@@ -18,18 +18,13 @@
 package scalismo.ui.api
 
 import java.awt.Color
-import java.awt.event.MouseEvent
 
-import scalismo.ui.control.interactor.Interactor.Verdict
 import scalismo.ui.control.interactor.landmark.complex.ComplexLandmarkingInteractor
 import scalismo.ui.control.interactor.landmark.complex.posterior.PosteriorLandmarkingInteractor
-import scalismo.ui.control.interactor.landmark.simple.SimpleLandmarkingInteractorTrait
-import scalismo.ui.control.interactor.{ DefaultInteractor, Interactor, Recipe }
+import scalismo.ui.control.interactor.{DefaultInteractor, Interactor}
 import scalismo.ui.model._
 import scalismo.ui.model.properties.Uncertainty
 import scalismo.ui.view.ScalismoFrame
-import scalismo.geometry._
-import scalismo.registration.RigidTransformationSpace
 
 private[api] sealed trait SimpleInteractor {
   type ConcreteInteractor <: Interactor

--- a/src/main/scala/scalismo/ui/api/Interactors.scala
+++ b/src/main/scala/scalismo/ui/api/Interactors.scala
@@ -19,8 +19,11 @@ package scalismo.ui.api
 
 import java.awt.Color
 
+import scalismo.geometry._3D
+import scalismo.registration.RigidTransformation
 import scalismo.ui.control.interactor.landmark.complex.ComplexLandmarkingInteractor
 import scalismo.ui.control.interactor.landmark.complex.posterior.PosteriorLandmarkingInteractor
+import scalismo.ui.control.interactor.landmark.simple
 import scalismo.ui.control.interactor.{ DefaultInteractor, Interactor }
 import scalismo.ui.model._
 import scalismo.ui.model.properties.Uncertainty
@@ -42,9 +45,9 @@ case class SimplePosteriorLandmarkingInteractor(ui: ScalismoUI, modelGroup: Grou
 
   type ConcreteInteractor = PosteriorLandmarkingInteractor
 
-  override protected[api] lazy val peer = new PosteriorLandmarkingInteractor {
+  override protected[api] lazy val peer: PosteriorLandmarkingInteractor = new PosteriorLandmarkingInteractor {
 
-    val meshView = ui.find[TriangleMeshView](modelGroup, (_: TriangleMeshView) => true).get
+    val meshView: TriangleMeshView = ui.find[TriangleMeshView](modelGroup, (_: TriangleMeshView) => true).get
 
     private val previewGroup = Group(ui.frame.scene.groups.add("__preview__", hidden = true))
 
@@ -57,7 +60,7 @@ case class SimplePosteriorLandmarkingInteractor(ui: ScalismoUI, modelGroup: Grou
     previewNode.color.value = Color.YELLOW
     previewNode.pickable.value = false
 
-    override val targetUncertaintyGroup = Group(ui.frame.scene.groups.add("__target_preview__", hidden = true)).peer
+    override val targetUncertaintyGroup: GroupNode = Group(ui.frame.scene.groups.add("__target_preview__", hidden = true)).peer
 
     override def sourceGpNode: TransformationNode[DiscreteLowRankGpPointTransformation] = modelGroup.peer.shapeModelTransformations.gaussianProcessTransformation.get
 
@@ -67,7 +70,7 @@ case class SimplePosteriorLandmarkingInteractor(ui: ScalismoUI, modelGroup: Grou
 
     override def frame: ScalismoFrame = ui.frame
 
-    override val inversePoseTransform = modelGroup.peer.shapeModelTransformations.poseTransformation.map(_.transformation.inverse).getOrElse(PointTransformation.RigidIdentity)
+    override val inversePoseTransform: RigidTransformation[_3D] = modelGroup.peer.shapeModelTransformations.poseTransformation.map(_.transformation.inverse).getOrElse(PointTransformation.RigidIdentity)
 
   }
 }
@@ -88,7 +91,7 @@ case class OneClickLandmarkingInteractor(ui: ScalismoUI, uncertainty: Uncertaint
 
   override type ConcreteInteractor = scalismo.ui.control.interactor.landmark.simple.SimpleLandmarkingInteractor.type
 
-  override protected[api] lazy val peer = scalismo.ui.control.interactor.landmark.simple.SimpleLandmarkingInteractor
+  override protected[api] lazy val peer: simple.SimpleLandmarkingInteractor.type = scalismo.ui.control.interactor.landmark.simple.SimpleLandmarkingInteractor
 
 }
 

--- a/src/main/scala/scalismo/ui/api/Interactors.scala
+++ b/src/main/scala/scalismo/ui/api/Interactors.scala
@@ -54,7 +54,7 @@ case class SimplePosteriorLandmarkingInteractor(ui: ScalismoUI, modelGroup: Grou
     modelGroup.peer.shapeModelTransformations.gaussianProcessTransformation.map(g => previewGroup.peer.shapeModelTransformations.addGaussianProcessTransformation(g.transformation))
 
     override val previewNode: TriangleMeshNode = ui.show(previewGroup, meshView.triangleMesh, "previewMesh").peer
-    frame.sceneControl.nodeVisibility.setVisibility(previewNode, frame.perspective.viewports, false)
+    frame.sceneControl.nodeVisibility.setVisibility(previewNode, frame.perspective.viewports, show = false)
     previewNode.color.value = Color.YELLOW
     previewNode.pickable.value = false
 

--- a/src/main/scala/scalismo/ui/api/Interactors.scala
+++ b/src/main/scala/scalismo/ui/api/Interactors.scala
@@ -44,8 +44,7 @@ case class SimplePosteriorLandmarkingInteractor(ui: ScalismoUI, modelGroup: Grou
 
   override protected[api] lazy val peer = new PosteriorLandmarkingInteractor {
 
-    val meshView = ui.find[TriangleMeshView](modelGroup, (p: TriangleMeshView) => true).get
-    //  val shapeTransformationView = ui.find[DiscreteLowRankGPTransformationView](modelGroup, (p: DiscreteLowRankGPTransformationView) => true).get
+    val meshView = ui.find[TriangleMeshView](modelGroup, (_: TriangleMeshView) => true).get
 
     private val previewGroup = Group(ui.frame.scene.groups.add("__preview__", hidden = true))
 

--- a/src/main/scala/scalismo/ui/api/Interactors.scala
+++ b/src/main/scala/scalismo/ui/api/Interactors.scala
@@ -21,7 +21,7 @@ import java.awt.Color
 
 import scalismo.ui.control.interactor.landmark.complex.ComplexLandmarkingInteractor
 import scalismo.ui.control.interactor.landmark.complex.posterior.PosteriorLandmarkingInteractor
-import scalismo.ui.control.interactor.{DefaultInteractor, Interactor}
+import scalismo.ui.control.interactor.{ DefaultInteractor, Interactor }
 import scalismo.ui.model._
 import scalismo.ui.model.properties.Uncertainty
 import scalismo.ui.view.ScalismoFrame

--- a/src/main/scala/scalismo/ui/api/ScalismoUI.scala
+++ b/src/main/scala/scalismo/ui/api/ScalismoUI.scala
@@ -19,14 +19,10 @@ package scalismo.ui.api
 
 import java.awt.Image
 
-import scalismo.ui.control.interactor.{ DefaultInteractor, Interactor }
-import scalismo.ui.model.{ GroupNode, SceneNode }
-import scalismo.ui.model.SceneNode.event.{ ChildAdded, ChildRemoved }
 import scalismo.ui.model.capabilities.RenderableSceneNode
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.util.EdtUtil
-import scalismo.ui.view.perspective.Perspective
-import scalismo.ui.view.{ ScalismoFrame, ScalismoLookAndFeel }
+import scalismo.ui.view.{ScalismoFrame, ScalismoLookAndFeel}
 
 class ScalismoUI(title: String) extends SimpleAPI with SimpleAPIDefaultImpl {
 

--- a/src/main/scala/scalismo/ui/api/ScalismoUI.scala
+++ b/src/main/scala/scalismo/ui/api/ScalismoUI.scala
@@ -43,7 +43,7 @@ class ScalismoUI(title: String) extends SimpleAPI with SimpleAPIDefaultImpl {
   override def setVisibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]) = {
 
     def setVisible(isVisible: Boolean, viewportName: String): Unit = {
-      frame.perspective.viewports.filter(_.name == viewportName).headOption.foreach { viewPort =>
+      frame.perspective.viewports.find(_.name == viewportName).foreach { viewPort =>
         val visib = frame.sceneControl.nodeVisibility
         visib.setVisibility(view.peer.asInstanceOf[RenderableSceneNode], viewPort, isVisible)
       }

--- a/src/main/scala/scalismo/ui/api/ScalismoUI.scala
+++ b/src/main/scala/scalismo/ui/api/ScalismoUI.scala
@@ -40,7 +40,7 @@ class ScalismoUI(title: String) extends SimpleAPI with SimpleAPIDefaultImpl {
   protected[api] val scene = fr.scene
   protected[api] val frame = fr
 
-  override def setVisibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]) = {
+  override def setVisibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]): Unit = {
 
     def setVisible(isVisible: Boolean, viewportName: String): Unit = {
       frame.perspective.viewports.find(_.name == viewportName).foreach { viewPort =>

--- a/src/main/scala/scalismo/ui/api/ScalismoUI.scala
+++ b/src/main/scala/scalismo/ui/api/ScalismoUI.scala
@@ -49,11 +49,11 @@ class ScalismoUI(title: String) extends SimpleAPI with SimpleAPIDefaultImpl {
       }
     }
 
-    visibleViewports.foreach(v => setVisible(true, v.name))
+    visibleViewports.foreach(v => setVisible(isVisible = true, v.name))
 
     //set invisible in other viewports
     val viewsNotInConfig = frame.perspective.viewports.filterNot(v => visibleViewports.exists(_.name == v.name))
-    viewsNotInConfig.foreach(v => setVisible(false, v.name))
+    viewsNotInConfig.foreach(v => setVisible(isVisible = false, v.name))
 
   }
 

--- a/src/main/scala/scalismo/ui/api/ScalismoUI.scala
+++ b/src/main/scala/scalismo/ui/api/ScalismoUI.scala
@@ -22,7 +22,7 @@ import java.awt.Image
 import scalismo.ui.model.capabilities.RenderableSceneNode
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.util.EdtUtil
-import scalismo.ui.view.{ScalismoFrame, ScalismoLookAndFeel}
+import scalismo.ui.view.{ ScalismoFrame, ScalismoLookAndFeel }
 
 class ScalismoUI(title: String) extends SimpleAPI with SimpleAPIDefaultImpl {
 

--- a/src/main/scala/scalismo/ui/api/ScalismoUI.scala
+++ b/src/main/scala/scalismo/ui/api/ScalismoUI.scala
@@ -19,6 +19,7 @@ package scalismo.ui.api
 
 import java.awt.Image
 
+import scalismo.ui.model.Scene
 import scalismo.ui.model.capabilities.RenderableSceneNode
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.util.EdtUtil
@@ -37,8 +38,8 @@ class ScalismoUI(title: String) extends SimpleAPI with SimpleAPIDefaultImpl {
     frame
   }
 
-  protected[api] val scene = fr.scene
-  protected[api] val frame = fr
+  protected[api] val scene: Scene = fr.scene
+  protected[api] val frame: ScalismoFrame = fr
 
   override def setVisibility[V <: ObjectView](view: V, visibleViewports: Seq[Viewport]): Unit = {
 

--- a/src/main/scala/scalismo/ui/api/ScalismoUIHeadless.scala
+++ b/src/main/scala/scalismo/ui/api/ScalismoUIHeadless.scala
@@ -16,6 +16,7 @@
  */
 
 package scalismo.ui.api
+
 import scalismo.ui.model.Scene
 
 case class ScalismoUIHeadless() extends SimpleAPI with SimpleAPIDefaultImpl {

--- a/src/main/scala/scalismo/ui/api/ShowInScene.scala
+++ b/src/main/scala/scalismo/ui/api/ShowInScene.scala
@@ -221,8 +221,8 @@ object ShowInScene extends LowPriorityImplicits {
 
     override def showInScene(transform: ShapeModelTransformation, name: String, group: Group): View = {
       val t = for {
-        pose <- group.peer.shapeModelTransformations.addPoseTransformation(transform.poseTransformation)
-        shape <- group.peer.shapeModelTransformations.addGaussianProcessTransformation(transform.shapeTransformation)
+        _ <- group.peer.shapeModelTransformations.addPoseTransformation(transform.poseTransformation)
+        _ <- group.peer.shapeModelTransformations.addGaussianProcessTransformation(transform.shapeTransformation)
       } yield ShapeModelTransformationView(group.peer.shapeModelTransformations)
       t.get
     }

--- a/src/main/scala/scalismo/ui/api/ShowInScene.scala
+++ b/src/main/scala/scalismo/ui/api/ShowInScene.scala
@@ -205,9 +205,11 @@ object ShowInScene extends LowPriorityImplicits {
 
     override type View = DiscreteLowRankGPTransformationView
 
-    override def showInScene(gp: DiscreteLowRankGaussianProcess[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]],
+    override def showInScene(
+      gp: DiscreteLowRankGaussianProcess[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]],
       name: String,
-      group: Group): View = {
+      group: Group
+    ): View = {
 
       val gpNode = group.peer.genericTransformations.add(DiscreteLowRankGpPointTransformation(gp), name)
       DiscreteLowRankGPTransformationView(gpNode)

--- a/src/main/scala/scalismo/ui/api/ShowInScene.scala
+++ b/src/main/scala/scalismo/ui/api/ShowInScene.scala
@@ -40,7 +40,9 @@ trait LowPriorityImplicits {
 
   def apply[A](implicit a: ShowInScene[A]): ShowInScene[A] = a
 
-  implicit def showInSceneScalarField[A: Scalar: ClassTag] =
+  implicit def showInSceneScalarField[A: Scalar: ClassTag]: ShowInScene[DiscreteScalarField[_3D, DiscreteDomain[_3D], A]] {
+    type View = ScalarFieldView
+  } =
     new ShowInScene[DiscreteScalarField[_3D, DiscreteDomain[_3D], A]] {
 
       override type View = ScalarFieldView
@@ -72,7 +74,9 @@ trait LowPriorityImplicits {
 
 object ShowInScene extends LowPriorityImplicits {
 
-  implicit def ShowVertexColorMesh = new ShowInScene[VertexColorMesh3D] {
+  implicit def ShowVertexColorMesh: ShowInScene[VertexColorMesh3D] {
+    type View = VertexColorMeshView
+  } = new ShowInScene[VertexColorMesh3D] {
     override type View = VertexColorMeshView
 
     override def showInScene(mesh: VertexColorMesh3D, name: String, group: Group): VertexColorMeshView = {
@@ -109,7 +113,9 @@ object ShowInScene extends LowPriorityImplicits {
     }
   }
 
-  implicit def ShowScalarField[S: Scalar: ClassTag] = new ShowInScene[ScalarMeshField[S]] {
+  implicit def ShowScalarField[S: Scalar: ClassTag]: ShowInScene[ScalarMeshField[S]] {
+    type View = ScalarMeshFieldView
+  } = new ShowInScene[ScalarMeshField[S]] {
     override type View = ScalarMeshFieldView
 
     override def showInScene(scalarMeshField: ScalarMeshField[S], name: String, group: Group): ScalarMeshFieldView = {
@@ -129,7 +135,9 @@ object ShowInScene extends LowPriorityImplicits {
     }
   }
 
-  implicit def ShowImage[S: Scalar: ClassTag] = new ShowInScene[DiscreteScalarImage[_3D, S]] {
+  implicit def ShowImage[S: Scalar: ClassTag]: ShowInScene[DiscreteScalarImage[_3D, S]] {
+    type View = ImageView
+  } = new ShowInScene[DiscreteScalarImage[_3D, S]] {
     override type View = ImageView
 
     override def showInScene(image: DiscreteScalarImage[_3D, S], name: String, group: Group): ImageView = {

--- a/src/main/scala/scalismo/ui/api/ShowInScene.scala
+++ b/src/main/scala/scalismo/ui/api/ShowInScene.scala
@@ -18,17 +18,15 @@
 package scalismo.ui.api
 
 import scalismo.common._
-import scalismo.geometry.{ Landmark, Point, EuclideanVector, _3D }
+import scalismo.geometry.{ EuclideanVector, Landmark, Point, _3D }
 import scalismo.image.DiscreteScalarImage
 import scalismo.mesh.{ LineMesh, ScalarMeshField, TriangleMesh, VertexColorMesh3D }
-import scalismo.registration.{ RigidTransformation, RigidTransformationSpace }
+import scalismo.registration.RigidTransformation
 import scalismo.statisticalmodel.{ DiscreteLowRankGaussianProcess, LowRankGaussianProcess, StatisticalMeshModel }
 import scalismo.ui.model._
-import scalismo.ui.view.ScalismoFrame
 
 import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
-import scala.util.Try
 
 @implicitNotFound(msg = "Don't know how to handle object (no implicit defined for ${A})")
 trait ShowInScene[-A] {

--- a/src/main/scala/scalismo/ui/api/ShowInScene.scala
+++ b/src/main/scala/scalismo/ui/api/ShowInScene.scala
@@ -53,7 +53,7 @@ trait LowPriorityImplicits {
   implicit object CreateGenericTransformation extends ShowInScene[Point[_3D] => Point[_3D]] {
     override type View = TransformationView
 
-    override def showInScene(t: (Point[_3D]) => Point[_3D], name: String, group: Group): View = {
+    override def showInScene(t: Point[_3D] => Point[_3D], name: String, group: Group): View = {
       TransformationView(group.peer.genericTransformations.add(t, name))
     }
   }

--- a/src/main/scala/scalismo/ui/api/SimpleAPIDefaultImpl.scala
+++ b/src/main/scala/scalismo/ui/api/SimpleAPIDefaultImpl.scala
@@ -61,7 +61,7 @@ trait SimpleAPIDefaultImpl {
     scene.listenTo(scene.groups)
 
     scene.reactions += {
-      case ChildAdded(collection, newNode: GroupNode) =>
+      case ChildAdded(_, newNode: GroupNode) =>
         val gv = Group(newNode)
         f(gv)
     }
@@ -71,7 +71,7 @@ trait SimpleAPIDefaultImpl {
     scene.listenTo(scene.groups)
 
     scene.reactions += {
-      case ChildRemoved(collection, newNode: GroupNode) =>
+      case ChildRemoved(_, newNode: GroupNode) =>
         val gv = Group(newNode)
         f(gv)
     }

--- a/src/main/scala/scalismo/ui/api/SimpleAPIDefaultImpl.scala
+++ b/src/main/scala/scalismo/ui/api/SimpleAPIDefaultImpl.scala
@@ -17,8 +17,8 @@
 
 package scalismo.ui.api
 
-import scalismo.ui.model.{ GroupNode, Scene, SceneNode }
 import scalismo.ui.model.SceneNode.event.{ ChildAdded, ChildRemoved }
+import scalismo.ui.model.{ GroupNode, Scene, SceneNode }
 
 trait SimpleAPIDefaultImpl {
   self: SimpleAPI =>

--- a/src/main/scala/scalismo/ui/api/SimplePluginAPI.scala
+++ b/src/main/scala/scalismo/ui/api/SimplePluginAPI.scala
@@ -35,11 +35,11 @@ trait SimplePluginAPI {
     onDeactivated()
   }
 
-  def message(message: String) = {
+  def message(message: String): Unit = {
     ui.frame.status.set(StatusMessage(message))
   }
 
-  def message(message: StatusMessage) = {
+  def message(message: StatusMessage): Unit = {
     ui.frame.status.set(StatusMessage(message.text, message.kind))
   }
 

--- a/src/main/scala/scalismo/ui/api/SimpleVisibility.scala
+++ b/src/main/scala/scalismo/ui/api/SimpleVisibility.scala
@@ -52,8 +52,8 @@ case object _3DMain extends Viewport {
 
 object Viewport {
 
-  val all = Seq(xView, yView, zView, _3DMain, _3DLeft, _3DRight)
-  val none = Seq()
+  val all: Seq[Viewport] = Seq(xView, yView, zView, _3DMain, _3DLeft, _3DRight)
+  val none: Seq[Viewport] = Seq()
   val xOnly: Seq[Viewport] = Seq(xView)
   val yOnly: Seq[Viewport] = Seq(yView)
   val zOnly: Seq[Viewport] = Seq(zView)

--- a/src/main/scala/scalismo/ui/api/TransformationGlyph.scala
+++ b/src/main/scala/scalismo/ui/api/TransformationGlyph.scala
@@ -18,7 +18,7 @@
 package scalismo.ui.api
 
 import scalismo.common.UnstructuredPointsDomain3D
-import scalismo.geometry.{ _3D, Point }
+import scalismo.geometry.{ Point, _3D }
 
 /**
  * A dummy class used only in the api to be able to show the transformation glyphs using a uniform syntax

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -57,14 +57,13 @@ object ObjectView {
 
       s match {
         case node: GroupNode => None // we ignore all group nodes, as they are not real objects
-        case node: SceneNode with Removeable => {
+        case node: SceneNode with Removeable =>
           val ov = new ObjectView {
             override type PeerType = SceneNode with Removeable
 
             override protected[api] def peer = node
           }
           Some(ov)
-        }
         case _ => None
       }
     }

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -596,7 +596,7 @@ object ImageView {
 }
 
 // Note this class does not extend Object view, as there is not really a corresponding node to this concept
-case class StatisticalMeshModelViewControls private[ui] (val meshView: TriangleMeshView, val shapeModelTransformationView: ShapeModelTransformationView)
+case class StatisticalMeshModelViewControls private[ui] (meshView: TriangleMeshView, shapeModelTransformationView: ShapeModelTransformationView)
 
 case class Group(override protected[api] val peer: GroupNode) extends ObjectView {
 

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -807,9 +807,9 @@ case class ShapeModelTransformationView private[ui] (override protected[api] val
     case None => throw new Exception("There is no rigid (pose) transformation associated with this ShapeModelTransformationView.")
   }
 
-  def hasShapeTransformation(): Boolean = peer.gaussianProcessTransformation.isDefined
+  def hasShapeTransformation: Boolean = peer.gaussianProcessTransformation.isDefined
 
-  def hasPoseTransformation(): Boolean = peer.poseTransformation.isDefined
+  def hasPoseTransformation: Boolean = peer.poseTransformation.isDefined
 
 }
 

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -77,19 +77,19 @@ case class PointCloudView private[ui] (override protected[api] val peer: PointCl
 
   type PeerType = PointCloudNode
 
-  def color = peer.color.value
+  def color: Color = peer.color.value
 
   def color_=(c: Color): Unit = {
     peer.color.value = c
   }
 
-  def radius = peer.radius.value
+  def radius: Double = peer.radius.value
 
   def radius_=(r: Double): Unit = {
     peer.radius.value = r
   }
 
-  def opacity = peer.opacity.value
+  def opacity: Double = peer.opacity.value
 
   def opacity_=(o: Double): Unit = {
     peer.opacity.value = o
@@ -136,19 +136,19 @@ object PointCloudView {
 case class TriangleMeshView private[ui] (override protected[api] val peer: TriangleMeshNode) extends ObjectView {
   type PeerType = TriangleMeshNode
 
-  def color = peer.color.value
+  def color: Color = peer.color.value
 
   def color_=(c: Color): Unit = {
     peer.color.value = c
   }
 
-  def opacity = peer.opacity.value
+  def opacity: Double = peer.opacity.value
 
   def opacity_=(o: Double): Unit = {
     peer.opacity.value = o
   }
 
-  def lineWidth = peer.lineWidth.value
+  def lineWidth: Int = peer.lineWidth.value
 
   def lineWidth_=(width: Int): Unit = {
     peer.lineWidth.value = width
@@ -198,13 +198,13 @@ case class VertexColorMeshView private[ui] (override protected[api] val peer: Ve
 
   type PeerType = VertexColorMeshNode
 
-  def opacity = peer.opacity.value
+  def opacity: Double = peer.opacity.value
 
   def opacity_=(o: Double): Unit = {
     peer.opacity.value = o
   }
 
-  def lineWidth = peer.lineWidth.value
+  def lineWidth: Int = peer.lineWidth.value
 
   def lineWidth_=(width: Int): Unit = {
     peer.lineWidth.value = width
@@ -253,19 +253,19 @@ case class LineMeshView private[ui] (override protected[api] val peer: LineMeshN
 
   type PeerType = LineMeshNode
 
-  def color = peer.color.value
+  def color: Color = peer.color.value
 
   def color_=(c: Color): Unit = {
     peer.color.value = c
   }
 
-  def opacity = peer.opacity.value
+  def opacity: Double = peer.opacity.value
 
   def opacity_=(o: Float): Unit = {
     peer.opacity.value = o
   }
 
-  def lineWidth = peer.lineWidth.value
+  def lineWidth: Int = peer.lineWidth.value
 
   def lineWidth_=(width: Int): Unit = {
     peer.lineWidth.value = width
@@ -315,13 +315,13 @@ case class LandmarkView private[ui] (override protected[api] val peer: LandmarkN
 
   type PeerType = LandmarkNode
 
-  def color = peer.color.value
+  def color: Color = peer.color.value
 
   def color_=(c: Color): Unit = {
     peer.color.value = c
   }
 
-  def opacity = peer.opacity.value
+  def opacity: Double = peer.opacity.value
 
   def opacity_=(o: Double): Unit = {
     peer.opacity.value = o
@@ -375,13 +375,13 @@ case class ScalarMeshFieldView private[ui] (override protected[api] val peer: Sc
     peer.scalarRange.value = s
   }
 
-  def opacity = peer.opacity.value
+  def opacity: Double = peer.opacity.value
 
   def opacity_=(o: Double): Unit = {
     peer.opacity.value = o
   }
 
-  def lineWidth = peer.lineWidth.value
+  def lineWidth: Int = peer.lineWidth.value
 
   def lineWidth_=(width: Int): Unit = {
     peer.lineWidth.value = width
@@ -389,7 +389,7 @@ case class ScalarMeshFieldView private[ui] (override protected[api] val peer: Sc
 
   def scalarMeshField: ScalarMeshField[Float] = peer.source
 
-  def transformedScalarMeshField = peer.transformedSource
+  def transformedScalarMeshField: ScalarMeshField[Float] = peer.transformedSource
 }
 
 object ScalarMeshFieldView {
@@ -435,13 +435,13 @@ case class ScalarFieldView private[ui] (override protected[api] val peer: Scalar
     peer.scalarRange.value = s
   }
 
-  def radius = peer.radius.value
+  def radius: Double = peer.radius.value
 
   def radius_=(r: Double): Unit = {
     peer.radius.value = r
   }
 
-  def opacity = peer.opacity.value
+  def opacity: Double = peer.opacity.value
 
   def opacity_=(o: Double): Unit = {
     peer.opacity.value = o
@@ -449,7 +449,7 @@ case class ScalarFieldView private[ui] (override protected[api] val peer: Scalar
 
   def scalarField: DiscreteScalarField[_3D, DiscreteDomain[_3D], Float] = peer.source
 
-  def transformedScalarField = peer.transformedSource
+  def transformedScalarField: DiscreteScalarField[_3D, DiscreteDomain[_3D], Float] = peer.transformedSource
 }
 
 object ScalarFieldView {
@@ -495,7 +495,7 @@ case class VectorFieldView private[ui] (override protected[api] val peer: Vector
     peer.scalarRange.value = s
   }
 
-  def opacity = peer.opacity.value
+  def opacity: Double = peer.opacity.value
 
   def opacity_=(o: Double): Unit = {
     peer.opacity.value = o
@@ -541,7 +541,7 @@ object VectorFieldView {
 case class ImageView private[ui] (override protected[api] val peer: ImageNode) extends ObjectView {
   type PeerType = ImageNode
 
-  def opacity = peer.opacity.value
+  def opacity: Double = peer.opacity.value
 
   def opacity_=(o: Double): Unit = {
     peer.opacity.value = o
@@ -553,7 +553,7 @@ case class ImageView private[ui] (override protected[api] val peer: ImageNode) e
     peer.windowLevel.value = peer.windowLevel.value.copy(window = w)
   }
 
-  def level = peer.windowLevel.value.level
+  def level: Double = peer.windowLevel.value.level
 
   def level_=(w: Double): Unit = {
     peer.windowLevel.value = peer.windowLevel.value.copy(level = w)
@@ -605,7 +605,7 @@ case class Group(override protected[api] val peer: GroupNode) extends ObjectView
     peer.hidden = b
   }
 
-  def hidden = peer.hidden
+  def hidden: Boolean = peer.hidden
 
   type PeerType = GroupNode
 }
@@ -721,7 +721,7 @@ case class DiscreteLowRankGPTransformationView private[ui] (override protected[a
 
   val transformation: DiscreteLowRankGpPointTransformation = peer.transformation
 
-  def discreteLowRankGaussianProcess = peer.transformation.dgp
+  def discreteLowRankGaussianProcess: DiscreteLowRankGaussianProcess[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]] = peer.transformation.dgp
 
   def discreteLowRankGaussianProcess_=(dgp: DiscreteLowRankGaussianProcess[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]]): Unit = {
     peer.transformation = DiscreteLowRankGpPointTransformation(dgp)
@@ -798,12 +798,12 @@ case class ShapeModelTransformationView private[ui] (override protected[api] val
 
   override type PeerType = ShapeModelTransformationsNode
 
-  def shapeTransformationView = peer.gaussianProcessTransformation.map(DiscreteLowRankGPTransformationView(_)) match {
+  def shapeTransformationView: DiscreteLowRankGPTransformationView = peer.gaussianProcessTransformation.map(DiscreteLowRankGPTransformationView(_)) match {
     case Some(sv) => sv
     case None => throw new Exception("There is no Gaussian Process (shape) transformation associated with this ShapeModelTransformationView.")
   }
 
-  def poseTransformationView = peer.poseTransformation.map(RigidTransformationView(_)) match {
+  def poseTransformationView: RigidTransformationView = peer.poseTransformation.map(RigidTransformationView(_)) match {
     case Some(sv) => sv
     case None => throw new Exception("There is no rigid (pose) transformation associated with this ShapeModelTransformationView.")
   }

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -25,13 +25,11 @@ import scalismo.geometry.{EuclideanVector, Landmark, Point, _3D}
 import scalismo.image.DiscreteScalarImage
 import scalismo.mesh.{LineMesh, ScalarMeshField, TriangleMesh, VertexColorMesh3D}
 import scalismo.registration.RigidTransformation
-import scalismo.statisticalmodel.{DiscreteLowRankGaussianProcess, StatisticalMeshModel}
-import scalismo.ui.control.NodeVisibility
+import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess
 import scalismo.ui.model.SceneNode.event.{ChildAdded, ChildRemoved}
 import scalismo.ui.model._
-import scalismo.ui.model.capabilities.{Removeable, RenderableSceneNode}
+import scalismo.ui.model.capabilities.Removeable
 import scalismo.ui.model.properties.ScalarRange
-import scalismo.ui.view.ScalismoFrame
 
 sealed trait ObjectView {
   type PeerType <: SceneNode with Removeable

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -51,6 +51,7 @@ sealed trait ObjectView {
 }
 
 object ObjectView {
+
   implicit object FindInSceneObjectView extends FindInScene[ObjectView] {
     override def createView(s: SceneNode): Option[ObjectView] = {
 
@@ -68,6 +69,7 @@ object ObjectView {
       }
     }
   }
+
 }
 
 case class PointCloudView private[ui] (override protected[api] val peer: PointCloudNode) extends ObjectView {
@@ -188,6 +190,7 @@ object TriangleMeshView {
     }
 
   }
+
 }
 
 case class VertexColorMeshView private[ui] (override protected[api] val peer: VertexColorMeshNode) extends ObjectView {
@@ -242,6 +245,7 @@ object VertexColorMeshView {
       }
     }
   }
+
 }
 
 case class LineMeshView private[ui] (override protected[api] val peer: LineMeshNode) extends ObjectView {
@@ -261,6 +265,7 @@ case class LineMeshView private[ui] (override protected[api] val peer: LineMeshN
   }
 
   def lineWidth = peer.lineWidth.value
+
   def lineWidth_=(width: Int): Unit = {
     peer.lineWidth.value = width
   }
@@ -302,6 +307,7 @@ object LineMeshView {
     }
 
   }
+
 }
 
 case class LandmarkView private[ui] (override protected[api] val peer: LandmarkNode) extends ObjectView {
@@ -375,6 +381,7 @@ case class ScalarMeshFieldView private[ui] (override protected[api] val peer: Sc
   }
 
   def lineWidth = peer.lineWidth.value
+
   def lineWidth_=(width: Int): Unit = {
     peer.lineWidth.value = width
   }
@@ -540,11 +547,13 @@ case class ImageView private[ui] (override protected[api] val peer: ImageNode) e
   }
 
   def window: Double = peer.windowLevel.value.window
+
   def window_=(w: Double): Unit = {
     peer.windowLevel.value = peer.windowLevel.value.copy(window = w)
   }
 
   def level = peer.windowLevel.value.level
+
   def level_=(w: Double): Unit = {
     peer.windowLevel.value = peer.windowLevel.value.copy(level = w)
   }
@@ -799,6 +808,7 @@ case class ShapeModelTransformationView private[ui] (override protected[api] val
   }
 
   def hasShapeTransformation(): Boolean = peer.gaussianProcessTransformation.isDefined
+
   def hasPoseTransformation(): Boolean = peer.poseTransformation.isDefined
 
 }

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -63,7 +63,7 @@ object ObjectView {
           val ov = new ObjectView {
             override type PeerType = SceneNode with Removeable
 
-            override protected[api] def peer = node
+            override protected[api] def peer: SceneNode with Removeable = node
           }
           Some(ov)
         case _ => None
@@ -111,7 +111,7 @@ object PointCloudView {
     }
   }
 
-  implicit def callbackPointCloudView = new HandleCallback[PointCloudView] {
+  implicit def callbackPointCloudView: HandleCallback[PointCloudView] = new HandleCallback[PointCloudView] {
 
     override def registerOnAdd[R](g: Group, f: PointCloudView => R): Unit = {
       g.peer.listenTo(g.peer.pointClouds)

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -58,7 +58,7 @@ object ObjectView {
     override def createView(s: SceneNode): Option[ObjectView] = {
 
       s match {
-        case node: GroupNode => None // we ignore all group nodes, as they are not real objects
+        case _: GroupNode => None // we ignore all group nodes, as they are not real objects
         case node: SceneNode with Removeable =>
           val ov = new ObjectView {
             override type PeerType = SceneNode with Removeable
@@ -116,7 +116,7 @@ object PointCloudView {
     override def registerOnAdd[R](g: Group, f: PointCloudView => R): Unit = {
       g.peer.listenTo(g.peer.pointClouds)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: PointCloudNode) =>
+        case ChildAdded(_, newNode: PointCloudNode) =>
           val tmv = PointCloudView(newNode)
           f(tmv)
       }
@@ -125,7 +125,7 @@ object PointCloudView {
     override def registerOnRemove[R](g: Group, f: PointCloudView => R): Unit = {
       g.peer.listenTo(g.peer.pointClouds)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: PointCloudNode) =>
+        case ChildRemoved(_, removedNode: PointCloudNode) =>
           val tmv = PointCloudView(removedNode)
           f(tmv)
       }
@@ -175,7 +175,7 @@ object TriangleMeshView {
     override def registerOnAdd[R](g: Group, f: TriangleMeshView => R): Unit = {
       g.peer.listenTo(g.peer.triangleMeshes)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: TriangleMeshNode) =>
+        case ChildAdded(_, newNode: TriangleMeshNode) =>
           val tmv = TriangleMeshView(newNode)
           f(tmv)
       }
@@ -184,7 +184,7 @@ object TriangleMeshView {
     override def registerOnRemove[R](g: Group, f: TriangleMeshView => R): Unit = {
       g.peer.listenTo(g.peer.triangleMeshes)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: TriangleMeshNode) =>
+        case ChildRemoved(_, removedNode: TriangleMeshNode) =>
           val tmv = TriangleMeshView(removedNode)
           f(tmv)
       }
@@ -231,7 +231,7 @@ object VertexColorMeshView {
     override def registerOnAdd[R](g: Group, f: VertexColorMeshView => R): Unit = {
       g.peer.listenTo(g.peer.colorMeshes)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: VertexColorMeshNode) =>
+        case ChildAdded(_, newNode: VertexColorMeshNode) =>
           val tmv = VertexColorMeshView(newNode)
           f(tmv)
       }
@@ -240,7 +240,7 @@ object VertexColorMeshView {
     override def registerOnRemove[R](g: Group, f: VertexColorMeshView => R): Unit = {
       g.peer.listenTo(g.peer.colorMeshes)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: VertexColorMeshNode) =>
+        case ChildRemoved(_, removedNode: VertexColorMeshNode) =>
           val tmv = VertexColorMeshView(removedNode)
           f(tmv)
       }
@@ -292,7 +292,7 @@ object LineMeshView {
     override def registerOnAdd[R](g: Group, f: LineMeshView => R): Unit = {
       g.peer.listenTo(g.peer.lineMeshes)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: LineMeshNode) =>
+        case ChildAdded(_, newNode: LineMeshNode) =>
           val lmv = LineMeshView(newNode)
           f(lmv)
       }
@@ -301,7 +301,7 @@ object LineMeshView {
     override def registerOnRemove[R](g: Group, f: LineMeshView => R): Unit = {
       g.peer.listenTo(g.peer.lineMeshes)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: LineMeshNode) =>
+        case ChildRemoved(_, removedNode: LineMeshNode) =>
           val lmv = LineMeshView(removedNode)
           f(lmv)
       }
@@ -348,7 +348,7 @@ object LandmarkView {
     override def registerOnAdd[R](g: Group, f: LandmarkView => R): Unit = {
       g.peer.listenTo(g.peer.landmarks)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: LandmarkNode) =>
+        case ChildAdded(_, newNode: LandmarkNode) =>
           val tmv = LandmarkView(newNode)
           f(tmv)
       }
@@ -357,7 +357,7 @@ object LandmarkView {
     override def registerOnRemove[R](g: Group, f: LandmarkView => R): Unit = {
       g.peer.listenTo(g.peer.landmarks)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: LandmarkNode) =>
+        case ChildRemoved(_, removedNode: LandmarkNode) =>
           val tmv = LandmarkView(removedNode)
           f(tmv)
       }
@@ -408,7 +408,7 @@ object ScalarMeshFieldView {
     override def registerOnAdd[R](g: Group, f: ScalarMeshFieldView => R): Unit = {
       g.peer.listenTo(g.peer.scalarMeshFields)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: ScalarMeshFieldNode) =>
+        case ChildAdded(_, newNode: ScalarMeshFieldNode) =>
           val tmv = ScalarMeshFieldView(newNode)
           f(tmv)
       }
@@ -417,7 +417,7 @@ object ScalarMeshFieldView {
     override def registerOnRemove[R](g: Group, f: ScalarMeshFieldView => R): Unit = {
       g.peer.listenTo(g.peer.scalarMeshFields)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: ScalarMeshFieldNode) =>
+        case ChildRemoved(_, removedNode: ScalarMeshFieldNode) =>
           val tmv = ScalarMeshFieldView(removedNode)
           f(tmv)
       }
@@ -468,7 +468,7 @@ object ScalarFieldView {
     override def registerOnAdd[R](g: Group, f: ScalarFieldView => R): Unit = {
       g.peer.listenTo(g.peer.scalarFields)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: ScalarFieldNode) =>
+        case ChildAdded(_, newNode: ScalarFieldNode) =>
           val tmv = ScalarFieldView(newNode)
           f(tmv)
       }
@@ -477,7 +477,7 @@ object ScalarFieldView {
     override def registerOnRemove[R](g: Group, f: ScalarFieldView => R): Unit = {
       g.peer.listenTo(g.peer.scalarFields)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: ScalarFieldNode) =>
+        case ChildRemoved(_, removedNode: ScalarFieldNode) =>
           val tmv = ScalarFieldView(removedNode)
           f(tmv)
       }
@@ -520,7 +520,7 @@ object VectorFieldView {
     override def registerOnAdd[R](g: Group, f: VectorFieldView => R): Unit = {
       g.peer.listenTo(g.peer.vectorFields)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: VectorFieldNode) =>
+        case ChildAdded(_, newNode: VectorFieldNode) =>
           val tmv = VectorFieldView(newNode)
           f(tmv)
       }
@@ -529,7 +529,7 @@ object VectorFieldView {
     override def registerOnRemove[R](g: Group, f: VectorFieldView => R): Unit = {
       g.peer.listenTo(g.peer.vectorFields)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: VectorFieldNode) =>
+        case ChildRemoved(_, removedNode: VectorFieldNode) =>
           val tmv = VectorFieldView(removedNode)
           f(tmv)
       }
@@ -578,7 +578,7 @@ object ImageView {
     override def registerOnAdd[R](g: Group, f: ImageView => R): Unit = {
       g.peer.listenTo(g.peer.images)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: ImageNode) =>
+        case ChildAdded(_, newNode: ImageNode) =>
           val imv = ImageView(newNode)
           f(imv)
       }
@@ -587,7 +587,7 @@ object ImageView {
     override def registerOnRemove[R](g: Group, f: ImageView => R): Unit = {
       g.peer.listenTo(g.peer.images)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: ImageNode) =>
+        case ChildRemoved(_, removedNode: ImageNode) =>
           val tmv = ImageView(removedNode)
           f(tmv)
       }
@@ -683,7 +683,7 @@ object RigidTransformationView {
     override def registerOnAdd[R](g: Group, f: RigidTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.genericTransformations)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: TransformationNode[_]) =>
+        case ChildAdded(_, newNode: TransformationNode[_]) =>
 
           if (newNode.transformation.isInstanceOf[RigidTransformation[_]]) {
             val tmv = RigidTransformationView(newNode.asInstanceOf[TransformationNode[RigidTransformation[_3D]]])
@@ -696,7 +696,7 @@ object RigidTransformationView {
     override def registerOnRemove[R](g: Group, f: RigidTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.genericTransformations)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: TransformationNode[_]) =>
+        case ChildRemoved(_, removedNode: TransformationNode[_]) =>
           if (removedNode.transformation.isInstanceOf[RigidTransformation[_]]) {
             val tmv = RigidTransformationView(removedNode.asInstanceOf[TransformationNode[RigidTransformation[_3D]]])
             f(tmv)
@@ -749,7 +749,7 @@ object DiscreteLowRankGPTransformationView {
     override def registerOnAdd[R](g: Group, f: DiscreteLowRankGPTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.genericTransformations)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: TransformationNode[_]) =>
+        case ChildAdded(_, newNode: TransformationNode[_]) =>
 
           if (newNode.transformation.isInstanceOf[DiscreteLowRankGpPointTransformation]) {
             val tmv = DiscreteLowRankGPTransformationView(newNode.asInstanceOf[TransformationNode[DiscreteLowRankGpPointTransformation]])
@@ -762,7 +762,7 @@ object DiscreteLowRankGPTransformationView {
     override def registerOnRemove[R](g: Group, f: DiscreteLowRankGPTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.genericTransformations)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: TransformationNode[_]) =>
+        case ChildRemoved(_, removedNode: TransformationNode[_]) =>
           if (removedNode.transformation.isInstanceOf[DiscreteLowRankGpPointTransformation]) {
             val tmv = DiscreteLowRankGPTransformationView(removedNode.asInstanceOf[TransformationNode[DiscreteLowRankGpPointTransformation]])
             f(tmv)
@@ -831,14 +831,14 @@ object ShapeModelTransformationView {
     override def registerOnAdd[R](g: Group, f: ShapeModelTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.shapeModelTransformations)
       g.peer.reactions += {
-        case ChildAdded(collection, newNode: TransformationNode[_]) => f(ShapeModelTransformationView(g.peer.shapeModelTransformations))
+        case ChildAdded(_, _: TransformationNode[_]) => f(ShapeModelTransformationView(g.peer.shapeModelTransformations))
       }
     }
 
     override def registerOnRemove[R](g: Group, f: ShapeModelTransformationView => R): Unit = {
       g.peer.listenTo(g.peer.shapeModelTransformations)
       g.peer.reactions += {
-        case ChildRemoved(collection, removedNode: TransformationNode[_]) => f(ShapeModelTransformationView(g.peer.shapeModelTransformations))
+        case ChildRemoved(_, _: TransformationNode[_]) => f(ShapeModelTransformationView(g.peer.shapeModelTransformations))
       }
     }
   }

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -45,8 +45,10 @@ sealed trait ObjectView {
   def remove(): Unit = peer.remove()
 
   private def findBelongingGroup(node: SceneNode): GroupNode = {
-    if (node.isInstanceOf[GroupNode]) node.asInstanceOf[GroupNode]
-    else findBelongingGroup(node.parent)
+    node match {
+      case groupNode: GroupNode => groupNode
+      case _ => findBelongingGroup(node.parent)
+    }
   }
 }
 

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -20,13 +20,13 @@ package scalismo.ui.api
 import java.awt.Color
 
 import breeze.linalg.DenseVector
-import scalismo.common.{DiscreteDomain, DiscreteField, DiscreteScalarField}
-import scalismo.geometry.{EuclideanVector, Landmark, Point, _3D}
+import scalismo.common.{ DiscreteDomain, DiscreteField, DiscreteScalarField }
+import scalismo.geometry.{ EuclideanVector, Landmark, Point, _3D }
 import scalismo.image.DiscreteScalarImage
-import scalismo.mesh.{LineMesh, ScalarMeshField, TriangleMesh, VertexColorMesh3D}
+import scalismo.mesh.{ LineMesh, ScalarMeshField, TriangleMesh, VertexColorMesh3D }
 import scalismo.registration.RigidTransformation
 import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess
-import scalismo.ui.model.SceneNode.event.{ChildAdded, ChildRemoved}
+import scalismo.ui.model.SceneNode.event.{ ChildAdded, ChildRemoved }
 import scalismo.ui.model._
 import scalismo.ui.model.capabilities.Removeable
 import scalismo.ui.model.properties.ScalarRange
@@ -190,7 +190,7 @@ object TriangleMeshView {
   }
 }
 
-case class VertexColorMeshView private[ui](override protected[api] val peer: VertexColorMeshNode) extends ObjectView {
+case class VertexColorMeshView private[ui] (override protected[api] val peer: VertexColorMeshNode) extends ObjectView {
 
   type PeerType = VertexColorMeshNode
 
@@ -243,8 +243,6 @@ object VertexColorMeshView {
     }
   }
 }
-
-
 
 case class LineMeshView private[ui] (override protected[api] val peer: LineMeshNode) extends ObjectView {
 

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -601,10 +601,10 @@ case class StatisticalMeshModelViewControls private[ui] (val meshView: TriangleM
 case class Group(override protected[api] val peer: GroupNode) extends ObjectView {
 
   def hidden_=(b: Boolean): Unit = {
-    peer.isGhost = b
+    peer.hidden = b
   }
 
-  def hidden = peer.isGhost
+  def hidden = peer.hidden
 
   type PeerType = GroupNode
 }

--- a/src/main/scala/scalismo/ui/control/NodeVisibility.scala
+++ b/src/main/scala/scalismo/ui/control/NodeVisibility.scala
@@ -25,7 +25,7 @@ import scalismo.ui.view._
 import scalismo.ui.view.perspective.Perspective
 
 import scala.collection.mutable
-import scala.language.implicitConversions
+//import scala.language.implicitConversions
 
 /**
  * This class controls the visibility of nodes in the various viewports of a frame.

--- a/src/main/scala/scalismo/ui/control/NodeVisibility.scala
+++ b/src/main/scala/scalismo/ui/control/NodeVisibility.scala
@@ -175,7 +175,7 @@ class NodeVisibility(frame: ScalismoFrame) extends ScalismoPublisher {
     setVisibility(List(node), List(viewport), show)
   }
 
-  private def handlePerspectiveChange(current: Perspective, previous: Perspective) = {
+  private def handlePerspectiveChange(current: Perspective, previous: Perspective): Unit = {
     // We keep it simple here, and only hide items if they have been completely hidden before.
     // anything else would just be guesswork.
 

--- a/src/main/scala/scalismo/ui/control/SlicingPosition.scala
+++ b/src/main/scala/scalismo/ui/control/SlicingPosition.scala
@@ -53,7 +53,7 @@ class SlicingPosition(val scene: Scene, val frame: ScalismoFrame) extends Scalis
 
   def visible = _visible
 
-  def visible_=(newVisible: Boolean) = {
+  def visible_=(newVisible: Boolean): Unit = {
     if (_visible != newVisible) {
       _visible = newVisible
       GlobalSettings.set(GlobalSettings.Keys.SlicingPositionShow, newVisible)
@@ -69,7 +69,7 @@ class SlicingPosition(val scene: Scene, val frame: ScalismoFrame) extends Scalis
     _point
   }
 
-  def point_=(np: Point3D) = {
+  def point_=(np: Point3D): Unit = {
     if (_point != np) {
       val prev = _point
       _point = np
@@ -83,21 +83,21 @@ class SlicingPosition(val scene: Scene, val frame: ScalismoFrame) extends Scalis
 
   def z = point(2)
 
-  def x_=(nv: Float) = {
+  def x_=(nv: Float): Unit = {
     val sv = Math.min(Math.max(boundingBox.xMin, nv), boundingBox.xMax)
     if (x != sv) {
       point_=(Point(sv, y, z))
     }
   }
 
-  def y_=(nv: Float) = {
+  def y_=(nv: Float): Unit = {
     val sv = Math.min(Math.max(boundingBox.yMin, nv), boundingBox.yMax)
     if (y != sv) {
       point = Point(x, sv, z)
     }
   }
 
-  def z_=(nv: Float) = {
+  def z_=(nv: Float): Unit = {
     val sv = Math.min(Math.max(boundingBox.zMin, nv), boundingBox.zMax)
     if (z != sv) {
       point = Point(x, y, sv)

--- a/src/main/scala/scalismo/ui/control/SlicingPosition.scala
+++ b/src/main/scala/scalismo/ui/control/SlicingPosition.scala
@@ -161,8 +161,8 @@ class SlicingPosition(val scene: Scene, val frame: ScalismoFrame) extends Scalis
 
   def renderablesFor(viewport: ViewportPanel): List[Renderable] = {
     viewport match {
-      case _3d: ViewportPanel3D => List(boundingBoxRenderable)
-      case _2d: ViewportPanel2D => List(boundingBoxRenderable)
+      case _: ViewportPanel3D => List(boundingBoxRenderable)
+      case _: ViewportPanel2D => List(boundingBoxRenderable)
     }
   }
 }

--- a/src/main/scala/scalismo/ui/control/SlicingPosition.scala
+++ b/src/main/scala/scalismo/ui/control/SlicingPosition.scala
@@ -51,7 +51,7 @@ class SlicingPosition(val scene: Scene, val frame: ScalismoFrame) extends Scalis
 
   private var _visible = GlobalSettings.get[Boolean](GlobalSettings.Keys.SlicingPositionShow).getOrElse(false)
 
-  def visible = _visible
+  def visible: Boolean = _visible
 
   def visible_=(newVisible: Boolean): Unit = {
     if (_visible != newVisible) {
@@ -65,7 +65,7 @@ class SlicingPosition(val scene: Scene, val frame: ScalismoFrame) extends Scalis
 
   private var _point: Point3D = Point3D(0, 0, 0)
 
-  def point = {
+  def point: Point3D = {
     _point
   }
 
@@ -77,11 +77,11 @@ class SlicingPosition(val scene: Scene, val frame: ScalismoFrame) extends Scalis
     }
   }
 
-  def x = point(0)
+  def x: Double = point(0)
 
-  def y = point(1)
+  def y: Double = point(1)
 
-  def z = point(2)
+  def z: Double = point(2)
 
   def x_=(nv: Float): Unit = {
     val sv = Math.min(Math.max(boundingBox.xMin, nv), boundingBox.xMax)
@@ -113,7 +113,7 @@ class SlicingPosition(val scene: Scene, val frame: ScalismoFrame) extends Scalis
 
   private var _boundingBox: BoundingBox = BoundingBox.Invalid
 
-  def boundingBox = _boundingBox
+  def boundingBox: BoundingBox = _boundingBox
 
   private def boundingBox_=(nb: BoundingBox): Unit = {
     if (_boundingBox != nb) {

--- a/src/main/scala/scalismo/ui/control/interactor/Interactor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/Interactor.scala
@@ -54,7 +54,7 @@ object Interactor {
  * This can be used for building complicated interaction state machines, as well as to selectively block events
  * from reaching the rendering implementation.
  *
- * Interactors are made active by using the [[ScalismoFrame.interactor]] setter.
+ * Interactors are made active by using the [[scalismo.ui.view.ScalismoFrame.interactor]] setter.
  *
  * They are invoked from the [[scalismo.ui.rendering.internal.EventInterceptor]] class, and if the verdict is to
  * pass on the event, it is handled by an [[scalismo.ui.rendering.internal.InteractorForwarder]], ultimately reaching

--- a/src/main/scala/scalismo/ui/control/interactor/Recipe.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/Recipe.scala
@@ -98,7 +98,7 @@ object Recipe {
     def mouseClicked(e: MouseEvent, uncertainty: Uncertainty = Uncertainty.DefaultUncertainty): Verdict = {
       val pointAndNode = e.viewport.rendererState.pointAndNodeAtPosition(e.getPoint)
       pointAndNode.nodeOption.foreach {
-        case skip: LandmarkNode => None
+        case _: LandmarkNode => None
         case ok: Grouped with InverseTransformation =>
           val name = ok.group.landmarks.nameGenerator.nextName()
           val point = ok.inverseTransform(pointAndNode.pointOption.get)
@@ -144,7 +144,7 @@ object Recipe {
   object Block2DRotation {
     def mousePressed(e: MouseEvent): Verdict = {
       e.viewport match {
-        case _2d: ViewportPanel2D if e.getButton == MouseEvent.BUTTON1 => Block
+        case _: ViewportPanel2D if e.getButton == MouseEvent.BUTTON1 => Block
         case _ => Pass
       }
     }

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ComplexLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ComplexLandmarkingInteractor.scala
@@ -105,7 +105,7 @@ trait ComplexLandmarkingInteractor[InteractorType <: ComplexLandmarkingInteracto
     val pointAndNode = e.viewport.rendererState.pointAndNodeAtPosition(e.getPoint)
     pointAndNode.nodeOption.flatMap { node =>
       val contextOption: Option[(Point3D, GroupNode)] = node match {
-        case skip: LandmarkNode => None
+        case _: LandmarkNode => None
         case ok: Grouped with InverseTransformation =>
           Some((ok.inverseTransform(pointAndNode.pointOption.get), ok.group))
         case ok: ImageNode =>
@@ -154,7 +154,7 @@ trait ComplexLandmarkingInteractor[InteractorType <: ComplexLandmarkingInteracto
           val axes = List(planeNormal, meshNormal, meshTangential).map { v => v * (1 / v.norm): EuclideanVector3D }
           val sigmas = sigmasForLandmarkUncertainty(group)
           Some((axes, sigmas))
-        case _3d: ViewportPanel3D =>
+        case _: ViewportPanel3D =>
           val meshNormal = mesh.vertexNormals(mesh.pointSet.findClosestPoint(point).id)
           val firstPerp = {
             /* There is an infinite number of perpendicular vectors, any one will do.

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ComplexLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ComplexLandmarkingInteractor.scala
@@ -60,7 +60,7 @@ trait ComplexLandmarkingInteractor[InteractorType <: ComplexLandmarkingInteracto
     selected = true
     val myIcon = BundledIcon.Landmark
 
-    def updateUi() = {
+    def updateUi(): Unit = {
       val onOff = if (selected) "ON" else "OFF"
       tooltip = s"Toggle landmarking (currently $onOff)"
       val iconColor = if (selected) Color.GREEN.darker else Color.DARK_GRAY

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ComplexLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ComplexLandmarkingInteractor.scala
@@ -58,7 +58,7 @@ trait ComplexLandmarkingInteractor[InteractorType <: ComplexLandmarkingInteracto
 
   private lazy val landmarkingButton: ToggleButton = new ToggleButton {
     selected = true
-    val myIcon = BundledIcon.Landmark
+    private val myIcon = BundledIcon.Landmark
 
     def updateUi(): Unit = {
       val onOff = if (selected) "ON" else "OFF"

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ComplexLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ComplexLandmarkingInteractor.scala
@@ -56,7 +56,7 @@ trait ComplexLandmarkingInteractor[InteractorType <: ComplexLandmarkingInteracto
 
   implicit lazy val myself: InteractorType = this.asInstanceOf[InteractorType]
 
-  private lazy val landmarkingButton = new ToggleButton {
+  private lazy val landmarkingButton: ToggleButton = new ToggleButton {
     selected = true
     val myIcon = BundledIcon.Landmark
 
@@ -74,7 +74,7 @@ trait ComplexLandmarkingInteractor[InteractorType <: ComplexLandmarkingInteracto
     updateUi()
   }
 
-  override protected def initialDelegate = {
+  override protected def initialDelegate: Delegate[InteractorType] = {
     if (isLandmarkCreationEnabled) {
       ReadyForCreating.enter()
     } else {

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ReadyForCreating.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ReadyForCreating.scala
@@ -41,7 +41,7 @@ class ReadyForCreating[InteractorType <: ComplexLandmarkingInteractor[Interactor
 
   override def mouseMoved(e: MouseEvent): Verdict = {
     def exceptLandmarks(node: SceneNode) = node match {
-      case nope: LandmarkNode => false
+      case _: LandmarkNode => false
       case _ => true
     }
 

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ReadyForCreating.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ReadyForCreating.scala
@@ -44,6 +44,7 @@ class ReadyForCreating[InteractorType <: ComplexLandmarkingInteractor[Interactor
       case nope: LandmarkNode => false
       case _ => true
     }
+
     Recipe.HighlightOutlineOfPickableObject.mouseMoved(e, exceptLandmarks)
   }
 

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ReadyForEditing.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ReadyForEditing.scala
@@ -43,6 +43,7 @@ class ReadyForEditing[InteractorType <: ComplexLandmarkingInteractor[InteractorT
       case yep: LandmarkNode => true
       case _ => false
     }
+
     Recipe.HighlightOutlineOfPickableObject.mouseMoved(e, onlyLandmarks)
   }
 

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ReadyForEditing.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/ReadyForEditing.scala
@@ -40,7 +40,7 @@ class ReadyForEditing[InteractorType <: ComplexLandmarkingInteractor[InteractorT
 
   override def mouseMoved(e: MouseEvent): Verdict = {
     def onlyLandmarks(node: SceneNode) = node match {
-      case yep: LandmarkNode => true
+      case _: LandmarkNode => true
       case _ => false
     }
 

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/posterior/PosteriorLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/posterior/PosteriorLandmarkingInteractor.scala
@@ -26,7 +26,6 @@ import scalismo.ui.model._
 
 trait PosteriorLandmarkingInteractor extends ComplexLandmarkingInteractor[PosteriorLandmarkingInteractor] {
 
-  implicit val theFrame = frame
   private lazy val nodeVisibility = frame.sceneControl.nodeVisibility
 
   def previewNode: TriangleMeshNode

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/posterior/PosteriorLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/posterior/PosteriorLandmarkingInteractor.scala
@@ -65,11 +65,11 @@ trait PosteriorLandmarkingInteractor extends ComplexLandmarkingInteractor[Poster
   }
 
   def showPreview(): Unit = {
-    nodeVisibility.setVisibility(previewNode, frame.perspective.viewports, true)
+    nodeVisibility.setVisibility(previewNode, frame.perspective.viewports, show = true)
   }
 
   def hidePreview(): Unit = {
-    nodeVisibility.setVisibility(previewNode, frame.perspective.viewports, false)
+    nodeVisibility.setVisibility(previewNode, frame.perspective.viewports, show = false)
   }
 
   def initialize(): Unit = {

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/complex/posterior/PosteriorLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/complex/posterior/PosteriorLandmarkingInteractor.scala
@@ -48,7 +48,7 @@ trait PosteriorLandmarkingInteractor extends ComplexLandmarkingInteractor[Poster
   def updatePreview(modelLm: LandmarkNode, targetLm: LandmarkNode, mousePosition: Point3D): Unit = {
 
     targetUncertaintyGroup.genericTransformations.foreach(_.remove())
-    targetUncertaintyGroup.genericTransformations.add((p: Point[_3D]) => mousePosition, "mousePosition")
+    targetUncertaintyGroup.genericTransformations.add((_: Point[_3D]) => mousePosition, "mousePosition")
 
     val lmPointAndId = {
       previewNode.source.pointSet.findClosestPoint(modelLm.source.point)

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
@@ -80,7 +80,7 @@ trait SimpleLandmarkingInteractorTrait extends Interactor {
   override def mouseMoved(e: MouseEvent): Verdict = {
     if (landmarkingButton.selected) {
       def exceptLandmarks(node: SceneNode) = node match {
-        case nope: LandmarkNode => false
+        case _: LandmarkNode => false
         case _ => true
       }
 

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
@@ -37,7 +37,7 @@ trait SimpleLandmarkingInteractorTrait extends Interactor {
   def defaultUncertainty: Uncertainty
 
   val landmarkingButton: ToggleButton = new ToggleButton {
-    val myIcon = BundledIcon.Landmark
+    private val myIcon = BundledIcon.Landmark
 
     def updateUi(): Unit = {
       val onOff = if (selected) "ON" else "OFF"
@@ -93,7 +93,7 @@ trait SimpleLandmarkingInteractorTrait extends Interactor {
 
 object SimpleLandmarkingInteractor extends SimpleLandmarkingInteractorTrait with DefaultInteractor {
 
-  override val defaultUncertainty = Uncertainty.DefaultUncertainty
+  override val defaultUncertainty: Uncertainty = Uncertainty.DefaultUncertainty
 
   override def mousePressed(e: MouseEvent): Verdict = Recipe.Block2DRotation.mousePressed(e)
 }

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
@@ -39,7 +39,7 @@ trait SimpleLandmarkingInteractorTrait extends Interactor {
   val landmarkingButton = new ToggleButton {
     val myIcon = BundledIcon.Landmark
 
-    def updateUi() = {
+    def updateUi(): Unit = {
       val onOff = if (selected) "ON" else "OFF"
       tooltip = s"Toggle landmarking (currently $onOff)"
       val iconColor = if (selected) Color.GREEN.darker else Color.DARK_GRAY

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
@@ -36,7 +36,7 @@ trait SimpleLandmarkingInteractorTrait extends Interactor {
 
   def defaultUncertainty: Uncertainty
 
-  val landmarkingButton = new ToggleButton {
+  val landmarkingButton: ToggleButton = new ToggleButton {
     val myIcon = BundledIcon.Landmark
 
     def updateUi(): Unit = {

--- a/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
+++ b/src/main/scala/scalismo/ui/control/interactor/landmark/simple/SimpleLandmarkingInteractor.scala
@@ -19,8 +19,8 @@ package scalismo.ui.control.interactor.landmark.simple
 
 import java.awt.event.MouseEvent
 import java.awt.{ Color, Cursor }
-import javax.swing.SwingUtilities
 
+import javax.swing.SwingUtilities
 import scalismo.ui.control.interactor.Interactor.Verdict
 import scalismo.ui.control.interactor.Interactor.Verdict.Pass
 import scalismo.ui.control.interactor.{ DefaultInteractor, Interactor, Recipe }
@@ -83,6 +83,7 @@ trait SimpleLandmarkingInteractorTrait extends Interactor {
         case nope: LandmarkNode => false
         case _ => true
       }
+
       Recipe.HighlightOutlineOfPickableObject.mouseMoved(e, exceptLandmarks)
     }
     super.mouseMoved(e)

--- a/src/main/scala/scalismo/ui/event/ScalismoPublisher.scala
+++ b/src/main/scala/scalismo/ui/event/ScalismoPublisher.scala
@@ -47,16 +47,16 @@ trait ScalismoPublisher extends Publisher {
    */
   @deprecated(message = "use method publishEvent instead", since = "always")
   @silent
-  override def publish(e: Event) = {
+  override def publish(e: Event): Unit = {
     doPublish(e)
   }
 
   // this is the preferred method to use
-  def publishEvent(e: Event) = {
+  def publishEvent(e: Event): Unit = {
     EdtUtil.onEdtWait(doPublish(e))
   }
 
-  private def doPublish(e: Event) = {
+  private def doPublish(e: Event): Unit = {
     // make sure that each listener is notified, even if the
     // listeners change during the handling.
     val copy = listeners.map(l => l)

--- a/src/main/scala/scalismo/ui/model/GroupNode.scala
+++ b/src/main/scala/scalismo/ui/model/GroupNode.scala
@@ -42,6 +42,7 @@ class GroupNode(override val parent: GroupsNode, initialName: String, private va
     _isGhost = b
     scene.publishEvent(SceneChanged(scene))
   }
+
   def isGhost = _isGhost
 
   val genericTransformations = new GenericTransformationsNode(this)

--- a/src/main/scala/scalismo/ui/model/GroupNode.scala
+++ b/src/main/scala/scalismo/ui/model/GroupNode.scala
@@ -25,8 +25,8 @@ import scalismo.ui.model.capabilities.{ Removeable, Renameable }
 class GroupsNode(override val parent: Scene) extends SceneNodeCollection[GroupNode] {
   override val name = "Groups"
 
-  def add(name: String, ghost: Boolean = false): GroupNode = {
-    val node = new GroupNode(this, name, ghost)
+  def add(name: String, hidden: Boolean = false): GroupNode = {
+    val node = new GroupNode(this, name, hidden)
     add(node)
     node
   }
@@ -35,15 +35,17 @@ class GroupsNode(override val parent: Scene) extends SceneNodeCollection[GroupNo
   override def isViewCollapsed: Boolean = true
 }
 
-class GroupNode(override val parent: GroupsNode, initialName: String, private var _isGhost: Boolean) extends SceneNode with Renameable with Removeable with ScalismoPublisher {
+class GroupNode(override val parent: GroupsNode, initialName: String, initallyHidden: Boolean) extends SceneNode with Renameable with Removeable with ScalismoPublisher {
   name = initialName
 
-  def isGhost_=(b: Boolean): Unit = {
-    _isGhost = b
+  private var _hidden = initallyHidden
+
+  def hidden_=(b: Boolean): Unit = {
+    _hidden = b
     scene.publishEvent(SceneChanged(scene))
   }
 
-  def isGhost = _isGhost
+  def hidden: Boolean = _hidden
 
   val genericTransformations = new GenericTransformationsNode(this)
   val shapeModelTransformations = new ShapeModelTransformationsNode(this)

--- a/src/main/scala/scalismo/ui/model/GroupNode.scala
+++ b/src/main/scala/scalismo/ui/model/GroupNode.scala
@@ -17,7 +17,6 @@
 
 package scalismo.ui.model
 
-import scalismo.registration.{ RigidTransformation, RigidTransformationSpace }
 import scalismo.statisticalmodel.StatisticalMeshModel
 import scalismo.ui.event.ScalismoPublisher
 import scalismo.ui.model.Scene.event.SceneChanged

--- a/src/main/scala/scalismo/ui/model/LandmarkNode.scala
+++ b/src/main/scala/scalismo/ui/model/LandmarkNode.scala
@@ -38,7 +38,7 @@ object LandmarksNode {
     private var prefix = 0
     private var suffix = 0
 
-    def nextName() = {
+    def nextName(): String = {
       val p = Prefixes(prefix)
       val name = if (suffix == 0) p.toString else s"${p}_$suffix"
       prefix = (prefix + 1) % Prefixes.length()

--- a/src/main/scala/scalismo/ui/model/LandmarkNode.scala
+++ b/src/main/scala/scalismo/ui/model/LandmarkNode.scala
@@ -47,7 +47,7 @@ object LandmarksNode {
       name
     }
 
-    def reset() = {
+    def reset(): Unit = {
       prefix = 0
       suffix = 0
     }

--- a/src/main/scala/scalismo/ui/model/LandmarkNode.scala
+++ b/src/main/scala/scalismo/ui/model/LandmarkNode.scala
@@ -26,7 +26,6 @@ import scalismo.ui.model.LandmarksNode.NameGenerator
 import scalismo.ui.model.capabilities._
 import scalismo.ui.model.properties._
 import scalismo.ui.util.{ FileIoMetadata, FileUtil }
-import scalismo.ui.view.action.popup.SaveLandmarksAction
 
 import scala.util.{ Failure, Success, Try }
 

--- a/src/main/scala/scalismo/ui/model/LineMeshNode.scala
+++ b/src/main/scala/scalismo/ui/model/LineMeshNode.scala
@@ -17,16 +17,10 @@
 
 package scalismo.ui.model
 
-import java.io.File
-
 import scalismo.geometry.{ Point3D, _3D }
-import scalismo.io.MeshIO
-import scalismo.mesh.{ LineMesh, TriangleMesh }
+import scalismo.mesh.LineMesh
 import scalismo.ui.model.capabilities._
 import scalismo.ui.model.properties._
-import scalismo.ui.util.{ FileIoMetadata, FileUtil }
-
-import scala.util.{ Failure, Success, Try }
 
 class LineMeshesNode(override val parent: GroupNode) extends SceneNodeCollection[LineMeshNode] {
   override val name: String = "Line Meshes"

--- a/src/main/scala/scalismo/ui/model/LowRankGpPointTransformation.scala
+++ b/src/main/scala/scalismo/ui/model/LowRankGpPointTransformation.scala
@@ -43,8 +43,10 @@ object LowRankGpPointTransformation {
 
 class DiscreteLowRankGpPointTransformation private (val dgp: DiscreteLowRankGaussianProcess[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]], gp: LowRankGaussianProcess[_3D, EuclideanVector[_3D]], coefficients: DenseVector[Double]) extends LowRankGpPointTransformation(gp, coefficients) {
 
-  protected def this(dgp: DiscreteLowRankGaussianProcess[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]],
-    coefficients: DenseVector[Double]) = {
+  protected def this(
+    dgp: DiscreteLowRankGaussianProcess[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]],
+    coefficients: DenseVector[Double]
+  ) = {
     this(dgp, dgp.interpolate(NearestNeighborInterpolator[_3D, EuclideanVector[_3D]]()), coefficients)
   }
 

--- a/src/main/scala/scalismo/ui/model/LowRankGpPointTransformation.scala
+++ b/src/main/scala/scalismo/ui/model/LowRankGpPointTransformation.scala
@@ -26,7 +26,7 @@ import scalismo.statisticalmodel.{ DiscreteLowRankGaussianProcess, LowRankGaussi
 // Therefore, the copy methods have to be defined manually.
 class LowRankGpPointTransformation protected (val gp: LowRankGaussianProcess[_3D, EuclideanVector[_3D]], val coefficients: DenseVector[Double]) extends PointTransformation {
 
-  lazy val vectorField = gp.instance(coefficients)
+  private lazy val vectorField = gp.instance(coefficients)
 
   override def apply(point: Point[_3D]): Point[_3D] = {
     point + vectorField(point)

--- a/src/main/scala/scalismo/ui/model/LowRankGpPointTransformation.scala
+++ b/src/main/scala/scalismo/ui/model/LowRankGpPointTransformation.scala
@@ -19,7 +19,7 @@ package scalismo.ui.model
 
 import breeze.linalg.DenseVector
 import scalismo.common.{ DiscreteDomain, NearestNeighborInterpolator }
-import scalismo.geometry.{ Point, EuclideanVector, _3D }
+import scalismo.geometry.{ EuclideanVector, Point, _3D }
 import scalismo.statisticalmodel.{ DiscreteLowRankGaussianProcess, LowRankGaussianProcess }
 
 // This used to be a case class, but since it is extended by the discrete version, it can no longer be.

--- a/src/main/scala/scalismo/ui/model/ScalarFieldNode.scala
+++ b/src/main/scala/scalismo/ui/model/ScalarFieldNode.scala
@@ -35,9 +35,11 @@ class ScalarFieldsNode(override val parent: GroupNode) extends SceneNodeCollecti
   }
 }
 
-class ScalarFieldNode(override val parent: ScalarFieldsNode,
+class ScalarFieldNode(
+  override val parent: ScalarFieldsNode,
   override val source: DiscreteScalarField[_3D, DiscreteDomain[_3D], Float],
-  initialName: String)
+  initialName: String
+)
     extends Transformable[DiscreteScalarField[_3D, DiscreteDomain[_3D], Float]]
     with InverseTransformation with Removeable with Renameable
     with HasOpacity with HasRadius with HasLineWidth with HasScalarRange {
@@ -56,8 +58,10 @@ class ScalarFieldNode(override val parent: ScalarFieldsNode,
 
   override def remove(): Unit = parent.remove(this)
 
-  override def transform(untransformed: DiscreteScalarField[_3D, DiscreteDomain[_3D], Float],
-    transformation: PointTransformation): DiscreteScalarField[_3D, DiscreteDomain[_3D], Float] = {
+  override def transform(
+    untransformed: DiscreteScalarField[_3D, DiscreteDomain[_3D], Float],
+    transformation: PointTransformation
+  ): DiscreteScalarField[_3D, DiscreteDomain[_3D], Float] = {
 
     val newDomain = untransformed.domain.transform(transformation)
     DiscreteScalarField(newDomain, untransformed.data)

--- a/src/main/scala/scalismo/ui/model/Scene.scala
+++ b/src/main/scala/scalismo/ui/model/Scene.scala
@@ -49,7 +49,7 @@ class Scene extends SceneNode {
   override val children: List[SceneNode] = List(groups)
 
   reactions += {
-    case ChildrenChanged(node) => publishEvent(SceneChanged(this))
+    case ChildrenChanged(_) => publishEvent(SceneChanged(this))
   }
 
 }

--- a/src/main/scala/scalismo/ui/model/Scene.scala
+++ b/src/main/scala/scalismo/ui/model/Scene.scala
@@ -17,11 +17,9 @@
 
 package scalismo.ui.model
 
-import scalismo.ui.control.SceneControl
 import scalismo.ui.event.Event
 import scalismo.ui.model.Scene.event.SceneChanged
 import scalismo.ui.model.SceneNode.event.ChildrenChanged
-import scalismo.ui.view.ScalismoFrame
 
 object Scene {
 

--- a/src/main/scala/scalismo/ui/model/SceneNodeCollection.scala
+++ b/src/main/scala/scalismo/ui/model/SceneNodeCollection.scala
@@ -29,7 +29,7 @@ object SceneNodeCollection {
 }
 
 trait SceneNodeCollection[ChildNode <: SceneNode] extends SceneNode with CollapsableView {
-  private var _items = mutable.ListBuffer.empty[ChildNode]
+  private val _items = mutable.ListBuffer.empty[ChildNode]
 
   override final def children: List[ChildNode] = _items.toList
 

--- a/src/main/scala/scalismo/ui/model/TransformationGlyphNode.scala
+++ b/src/main/scala/scalismo/ui/model/TransformationGlyphNode.scala
@@ -18,7 +18,7 @@
 package scalismo.ui.model
 
 import scalismo.common.{ DiscreteDomain, DiscreteField, UnstructuredPointsDomain }
-import scalismo.geometry.{ Point3D, EuclideanVector, EuclideanVector3D, _3D }
+import scalismo.geometry.{ EuclideanVector, EuclideanVector3D, Point3D, _3D }
 import scalismo.ui.model.capabilities._
 
 class TransformationGlyphNode(override val parent: VectorFieldsNode, val points: PointCloud, initialName: String)

--- a/src/main/scala/scalismo/ui/model/TransformationGlyphNode.scala
+++ b/src/main/scala/scalismo/ui/model/TransformationGlyphNode.scala
@@ -24,7 +24,7 @@ import scalismo.ui.model.capabilities._
 class TransformationGlyphNode(override val parent: VectorFieldsNode, val points: PointCloud, initialName: String)
     extends VectorFieldNode(parent, DiscreteField(UnstructuredPointsDomain(points), points.map(_ => EuclideanVector3D(0, 0, 0))), initialName) with Transformable[DiscreteField[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]]] with InverseTransformation {
 
-  lazy val glyphPoints = points.toIndexedSeq
+  private lazy val glyphPoints = points.toIndexedSeq
 
   override def transform(untransformed: DiscreteField[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]], transformation: PointTransformation): DiscreteField[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]] = {
     DiscreteField(untransformed.domain, glyphPoints.map(p => transformation(p) - p))

--- a/src/main/scala/scalismo/ui/model/TransformationNode.scala
+++ b/src/main/scala/scalismo/ui/model/TransformationNode.scala
@@ -88,17 +88,17 @@ class GenericTransformationsNode(override val parent: GroupNode) extends Transfo
 class ShapeModelTransformationsNode(override val parent: GroupNode) extends TransformationCollectionNode with Removeable {
   override val name: String = "Shape model transformations"
 
-  private def isPoseDefined(): Boolean = {
+  private def isPoseDefined: Boolean = {
     children.exists(tr => tr.transformation.isInstanceOf[RigidTransformation[_3D]])
   }
 
-  private def isShapeDefined(): Boolean = {
+  private def isShapeDefined: Boolean = {
     children.exists(tr => tr.transformation.isInstanceOf[DiscreteLowRankGpPointTransformation])
   }
 
   def addPoseTransformation(transformation: RigidTransformation[_3D], name: String = "pose"): Try[ShapeModelTransformationComponentNode[RigidTransformation[_3D]]] = {
 
-    if (isPoseDefined()) {
+    if (isPoseDefined) {
       Failure(new Exception("The group already contains a rigid transformation as part of the Shape Model Transformation. Remove existing first"))
     } else {
       val node = ShapeModelTransformationComponentNode(this, transformation, name)
@@ -109,7 +109,7 @@ class ShapeModelTransformationsNode(override val parent: GroupNode) extends Tran
 
   def addGaussianProcessTransformation(transformation: DiscreteLowRankGpPointTransformation, name: String = "shape"): Try[ShapeModelTransformationComponentNode[DiscreteLowRankGpPointTransformation]] = {
 
-    if (isShapeDefined()) {
+    if (isShapeDefined) {
       Failure(new Exception("The group already contains a GP transformation as part of the Shape Model Transformation. Remove existing first"))
     } else {
       val node = ShapeModelTransformationComponentNode(this, transformation, name)

--- a/src/main/scala/scalismo/ui/model/TransformationNode.scala
+++ b/src/main/scala/scalismo/ui/model/TransformationNode.scala
@@ -91,6 +91,7 @@ class ShapeModelTransformationsNode(override val parent: GroupNode) extends Tran
   private def isPoseDefined(): Boolean = {
     children.exists(tr => tr.transformation.isInstanceOf[RigidTransformation[_3D]])
   }
+
   private def isShapeDefined(): Boolean = {
     children.exists(tr => tr.transformation.isInstanceOf[DiscreteLowRankGpPointTransformation])
   }
@@ -161,7 +162,9 @@ class ShapeModelTransformationsNode(override val parent: GroupNode) extends Tran
 
 class ShapeModelTransformationComponentNode[T <: PointTransformation] private (override val parent: ShapeModelTransformationsNode, initialTransformation: T, override val name: String)
     extends TransformationNode[T](parent, initialTransformation, name) {
-  override def remove(): Unit = { parent.remove(this) }
+  override def remove(): Unit = {
+    parent.remove(this)
+  }
 }
 
 object ShapeModelTransformationComponentNode {

--- a/src/main/scala/scalismo/ui/model/VectorFieldNode.scala
+++ b/src/main/scala/scalismo/ui/model/VectorFieldNode.scala
@@ -22,6 +22,8 @@ import scalismo.geometry._
 import scalismo.ui.model.capabilities._
 import scalismo.ui.model.properties._
 
+import scala.collection.immutable
+
 class VectorFieldsNode(override val parent: GroupNode) extends SceneNodeCollection[VectorFieldNode] {
   override val name: String = "Scalar fields"
 
@@ -50,7 +52,7 @@ class VectorFieldNode(
 
   // we store the vectors as a sequence, as values are defined by iterators, which we cannot
   // traverse twice
-  lazy val vectors = source.values.toIndexedSeq
+  private lazy val vectors: immutable.IndexedSeq[EuclideanVector[_3D]] = source.values.toIndexedSeq
 
   override val opacity = new OpacityProperty()
   override val lineWidth = new LineWidthProperty()

--- a/src/main/scala/scalismo/ui/model/VectorFieldNode.scala
+++ b/src/main/scala/scalismo/ui/model/VectorFieldNode.scala
@@ -38,9 +38,11 @@ class VectorFieldsNode(override val parent: GroupNode) extends SceneNodeCollecti
   }
 }
 
-class VectorFieldNode(override val parent: VectorFieldsNode,
+class VectorFieldNode(
+  override val parent: VectorFieldsNode,
   val source: DiscreteField[_3D, DiscreteDomain[_3D], EuclideanVector[_3D]],
-  initialName: String)
+  initialName: String
+)
     extends RenderableSceneNode with Removeable with Renameable with Grouped
     with HasOpacity with HasLineWidth with HasScalarRange {
 

--- a/src/main/scala/scalismo/ui/model/VertexColorMeshNode.scala
+++ b/src/main/scala/scalismo/ui/model/VertexColorMeshNode.scala
@@ -19,8 +19,7 @@ package scalismo.ui.model
 
 import java.io.File
 
-import scalismo.geometry.{ Point, Point3D, _3D }
-import scalismo.geometry
+import scalismo.geometry.Point3D
 import scalismo.io.MeshIO
 import scalismo.mesh.VertexColorMesh3D
 import scalismo.ui.model.capabilities._

--- a/src/main/scala/scalismo/ui/model/capabilities/Renameable.scala
+++ b/src/main/scala/scalismo/ui/model/capabilities/Renameable.scala
@@ -18,7 +18,7 @@
 package scalismo.ui.model.capabilities
 
 trait Renameable {
-  private var _name: String = null
+  private var _name: String = _ // default: null
 
   def name = if (_name == null) "(null)" else _name
 

--- a/src/main/scala/scalismo/ui/model/capabilities/Renameable.scala
+++ b/src/main/scala/scalismo/ui/model/capabilities/Renameable.scala
@@ -22,7 +22,7 @@ trait Renameable {
 
   def name = if (_name == null) "(null)" else _name
 
-  def name_=(newValue: String) = {
+  def name_=(newValue: String): Unit = {
     _name = newValue
   }
 }

--- a/src/main/scala/scalismo/ui/model/capabilities/Renameable.scala
+++ b/src/main/scala/scalismo/ui/model/capabilities/Renameable.scala
@@ -20,7 +20,7 @@ package scalismo.ui.model.capabilities
 trait Renameable {
   private var _name: String = _ // default: null
 
-  def name = if (_name == null) "(null)" else _name
+  def name: String = if (_name == null) "(null)" else _name
 
   def name_=(newValue: String): Unit = {
     _name = newValue

--- a/src/main/scala/scalismo/ui/model/capabilities/RenderableSceneNode.scala
+++ b/src/main/scala/scalismo/ui/model/capabilities/RenderableSceneNode.scala
@@ -30,9 +30,3 @@ trait RenderableSceneNode extends SceneNode with Renderable {
 
   final override def children: List[SceneNode] = Nil
 }
-
-object RenderableSceneNode {
-
-  import scala.language.implicitConversions
-
-}

--- a/src/main/scala/scalismo/ui/model/capabilities/Transformable.scala
+++ b/src/main/scala/scalismo/ui/model/capabilities/Transformable.scala
@@ -34,6 +34,7 @@ trait Transformable[T] extends RenderableSceneNode with Grouped {
   def source: T // the untransformed T
 
   private def genericTransformationsNode: GenericTransformationsNode = group.genericTransformations
+
   private def shapeModelTransformationsNode: ShapeModelTransformationsNode = group.shapeModelTransformations
 
   private def combinedTransform = shapeModelTransformationsNode.combinedTransformation.map(smT => genericTransformationsNode.combinedTransformation compose smT) getOrElse {

--- a/src/main/scala/scalismo/ui/model/properties/ColorProperty.scala
+++ b/src/main/scala/scalismo/ui/model/properties/ColorProperty.scala
@@ -38,7 +38,7 @@ object ColorProperty extends ScalismoPublisher {
 class ColorProperty(initialValue: Color) extends NodeProperty[Color](initialValue) {
   def this() = this(ColorProperty.DefaultValue)
 
-  override def value_=(newValue: Color) = {
+  override def value_=(newValue: Color): Unit = {
     super.value_=(newValue)
     ColorProperty.publishEvent(ColorProperty.event.SomeColorPropertyChanged)
   }

--- a/src/main/scala/scalismo/ui/model/properties/LineWidthProperty.scala
+++ b/src/main/scala/scalismo/ui/model/properties/LineWidthProperty.scala
@@ -20,8 +20,7 @@ package scalismo.ui.model.properties
 object LineWidthProperty {
   val DefaultValue: Int = 1
 
-  // this is a var so it can be changed if needed, but that is not recommended.
-  var MaxValue: Int = 7
+  val MaxValue: Int = 7
 }
 
 class LineWidthProperty(initialValue: Int) extends NodeProperty[Int](initialValue) {

--- a/src/main/scala/scalismo/ui/model/properties/NodeProperty.scala
+++ b/src/main/scala/scalismo/ui/model/properties/NodeProperty.scala
@@ -46,7 +46,7 @@ class NodeProperty[V](initialValue: => V) extends ScalismoPublisher {
 
   def value: V = _value
 
-  def value_=(newValue: V) = {
+  def value_=(newValue: V): Unit = {
     _value = sanitize(newValue)
     publishEvent(PropertyChanged(this))
   }

--- a/src/main/scala/scalismo/ui/model/properties/NodeProperty.scala
+++ b/src/main/scala/scalismo/ui/model/properties/NodeProperty.scala
@@ -40,7 +40,7 @@ class NodeProperty[V](initialValue: => V) extends ScalismoPublisher {
    * @param possiblyNotSane a value, possibly not a sane one
    * @return the sanitized version of the value
    */
-  protected def sanitize(possiblyNotSane: V) = possiblyNotSane
+  protected def sanitize(possiblyNotSane: V): V = possiblyNotSane
 
   private var _value: V = sanitize(initialValue)
 

--- a/src/main/scala/scalismo/ui/model/properties/Uncertainty.scala
+++ b/src/main/scala/scalismo/ui/model/properties/Uncertainty.scala
@@ -23,7 +23,17 @@ import scalismo.statisticalmodel.MultivariateNormalDistribution
 
 object Uncertainty {
   val DefaultAxes = List(EuclideanVector3D(1, 0, 0), EuclideanVector3D(0, 1, 0), EuclideanVector3D(0, 0, 1))
+
+  //noinspection VarCouldBeVal
+  /* This is a global variable that can be set by developers using the library.
+   * The "noinspection" comment suppresses a "var could be val" warning from IntelliJ IDEA.
+   */
   var DefaultSigmas: List[Double] = List(1, 1, 1)
+
+  //noinspection VarCouldBeVal
+  /* This is a global variable that can be set by developers using the library.
+   * The "noinspection" comment suppresses a "var could be val" warning from IntelliJ IDEA.
+   */
   var DefaultUncertainty: Uncertainty = Uncertainty(DefaultAxes, DefaultSigmas)
 
   def apply(distribution: MultivariateNormalDistribution): Uncertainty = {

--- a/src/main/scala/scalismo/ui/model/properties/Uncertainty.scala
+++ b/src/main/scala/scalismo/ui/model/properties/Uncertainty.scala
@@ -19,7 +19,7 @@ package scalismo.ui.model.properties
 
 import scalismo.geometry.EuclideanVector._
 import scalismo.geometry._
-import scalismo.statisticalmodel.{ MultivariateNormalDistribution, NDimensionalNormalDistribution }
+import scalismo.statisticalmodel.MultivariateNormalDistribution
 
 object Uncertainty {
   val DefaultAxes = List(EuclideanVector3D(1, 0, 0), EuclideanVector3D(0, 1, 0), EuclideanVector3D(0, 0, 1))

--- a/src/main/scala/scalismo/ui/rendering/RendererPanel.scala
+++ b/src/main/scala/scalismo/ui/rendering/RendererPanel.scala
@@ -202,8 +202,8 @@ class RendererPanel(viewport: ViewportPanel) extends BorderPanel {
 
         def prioritize(a1: vtkActor, a2: vtkActor): Boolean = {
           (a1, a2) match {
-            case (i1: IsImageActor, i2: IsImageActor) => false
-            case (i1: IsImageActor, _) => true
+            case (_: IsImageActor, _: IsImageActor) => false
+            case (_: IsImageActor, _) => true
             case (_, _) => false
           }
         }

--- a/src/main/scala/scalismo/ui/rendering/actor/ActorEvents.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/ActorEvents.scala
@@ -53,7 +53,7 @@ trait ActorEvents extends ScalismoPublisher {
   //  def actorGeometryChanged(): Unit = {
   //    publishEvent(ActorEvents.event.ActorGeometryChanged(this))
   //  }
-  def actorChanged(didGeometryChange: Boolean = false) = {
+  def actorChanged(didGeometryChange: Boolean = false): Unit = {
     publishEvent(ActorEvents.event.ActorChanged(this, didGeometryChange))
   }
 

--- a/src/main/scala/scalismo/ui/rendering/actor/BoundingBoxActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/BoundingBoxActor.scala
@@ -45,7 +45,7 @@ class BoundingBoxActor3D(slicingPosition: SlicingPosition) extends PolyDataActor
 
   override def vtkActors: List[vtkActor] = this :: sliceActors
 
-  def update() = {
+  def update(): Unit = {
     val points = new vtkPoints()
     val bb = slicingPosition.boundingBox
     points.InsertNextPoint(bb.xMin, bb.yMin, bb.zMin)
@@ -109,7 +109,7 @@ trait BoundingBoxActor2D extends PolyDataActor with ActorEvents {
 
   def intersectionActors: List[BoundingBoxIntersectionActor] = Nil
 
-  def update() = {
+  def update(): Unit = {
     // this is a (minimally) more expensive way to construct what will end up being
     // a rectangle anyway, but it's extremely concise and much more understandable than manual construction.
 
@@ -169,7 +169,7 @@ trait BoundingBoxActor2D extends PolyDataActor with ActorEvents {
 
 // this class draws the intersection line for a particular axis in a BoundingBoxActor2D
 class BoundingBoxIntersectionActor(axis: Axis) extends PolyDataActor {
-  def update(bb: BoundingBox, point: Point3D, overrideIndex: Int, overrideValue: Double) = {
+  def update(bb: BoundingBox, point: Point3D, overrideIndex: Int, overrideValue: Double): Unit = {
     val min = Array(bb.xMin, bb.yMin, bb.zMin)
     val max = Array(bb.xMax, bb.yMax, bb.zMax)
 

--- a/src/main/scala/scalismo/ui/rendering/actor/BoundingBoxActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/BoundingBoxActor.scala
@@ -41,7 +41,7 @@ class BoundingBoxActor3D(slicingPosition: SlicingPosition) extends PolyDataActor
   // this actor is displaying the bounding box, but doesn't "have" one itself (i.e., doesn't affect it).
   override def boundingBox: BoundingBox = BoundingBox.Invalid
 
-  val sliceActors = Axis.All.map(axis => BoundingBoxActor2D(axis, slicingPosition))
+  private val sliceActors = Axis.All.map(axis => BoundingBoxActor2D(axis, slicingPosition))
 
   override def vtkActors: List[vtkActor] = this :: sliceActors
 
@@ -84,7 +84,7 @@ class BoundingBoxActor3D(slicingPosition: SlicingPosition) extends PolyDataActor
 class SingleBoundingBoxActor2D(override val slicingPosition: SlicingPosition, override val axis: Axis) extends BoundingBoxActor2D with Actors {
   override def boundingBox: BoundingBox = BoundingBox.Invalid
 
-  override lazy val intersectionActors = {
+  override lazy val intersectionActors: List[BoundingBoxIntersectionActor] = {
     Axis.All.filterNot(_ == axis).map { iAxis =>
       new BoundingBoxIntersectionActor(iAxis)
     }

--- a/src/main/scala/scalismo/ui/rendering/actor/BoundingBoxActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/BoundingBoxActor.scala
@@ -31,7 +31,7 @@ import vtk._
 object BoundingBoxActor extends SimpleActorsFactory[SlicingPosition.renderable.BoundingBoxRenderable] {
   override def actorsFor(renderable: BoundingBoxRenderable, viewport: ViewportPanel): Option[Actors] = {
     viewport match {
-      case _3d: ViewportPanel3D => Some(new BoundingBoxActor3D(renderable.source))
+      case _: ViewportPanel3D => Some(new BoundingBoxActor3D(renderable.source))
       case _2d: ViewportPanel2D => Some(new SingleBoundingBoxActor2D(renderable.source, _2d.axis))
     }
   }

--- a/src/main/scala/scalismo/ui/rendering/actor/ImageActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/ImageActor.scala
@@ -19,7 +19,7 @@ package scalismo.ui.rendering.actor
 
 import scalismo.geometry.Point3D
 import scalismo.ui.control.SlicingPosition
-import scalismo.ui.model.properties.NodeProperty
+import scalismo.ui.model.properties.{ NodeProperty, OpacityProperty }
 import scalismo.ui.model.{ Axis, BoundingBox, ImageNode }
 import scalismo.ui.rendering.Caches
 import scalismo.ui.rendering.actor.ImageActor2D.InstanceData
@@ -40,7 +40,7 @@ object ImageActor extends SimpleActorsFactory[ImageNode] {
 
 object ImageActor2D {
 
-  def apply(node: ImageNode, viewport: ViewportPanel2D) = new ImageActor2D(node, viewport.axis, viewport.frame) with SinglePolyDataActor {
+  def apply(node: ImageNode, viewport: ViewportPanel2D): ImageActor2D with SinglePolyDataActor = new ImageActor2D(node, viewport.axis, viewport.frame) with SinglePolyDataActor {
     override def boundingBox: BoundingBox = VtkUtil.bounds2BoundingBox(data.points.GetBounds())
   }
 
@@ -92,7 +92,7 @@ object ImageActor2D {
 
 class ImageActor2D private[ImageActor2D] (override val sceneNode: ImageNode, axis: Axis, frame: ScalismoFrame) extends PolyDataActor with IsImageActor with ActorOpacity with ActorEvents with ActorSceneNode {
 
-  override def opacity = sceneNode.opacity
+  override def opacity: OpacityProperty = sceneNode.opacity
 
   val data = new InstanceData(sceneNode, axis)
 

--- a/src/main/scala/scalismo/ui/rendering/actor/ImageActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/ImageActor.scala
@@ -97,7 +97,7 @@ class ImageActor2D private[ImageActor2D] (override val sceneNode: ImageNode, axi
   val data = new InstanceData(sceneNode, axis)
 
   // This method computes the closest into the image for the given slicing position (point) for a given axis.
-  def point3DToSliceIndex(p: Point3D, axis: Axis): (Int) = {
+  def point3DToSliceIndex(p: Point3D, axis: Axis): Int = {
     val (fmin, fmax, fval, tmax) = axis match {
       case Axis.X => (data.min, data.max, p.x, data.exmax)
       case Axis.Y => (data.min, data.max, p.y, data.eymax)
@@ -128,27 +128,24 @@ class ImageActor2D private[ImageActor2D] (override val sceneNode: ImageNode, axi
       data.sliceCorrectionTransform.Identity()
 
       def computeOffset(component: Int): Double = {
-        val pointComponentForIndex = (origin(component) + sliceIndex * spacing(component))
-        val offset = (slicingPoint(component) - pointComponentForIndex)
+        val pointComponentForIndex = origin(component) + sliceIndex * spacing(component)
+        val offset = slicingPoint(component) - pointComponentForIndex
         offset
       }
 
       axis match {
-        case Axis.X => {
+        case Axis.X =>
           data.slice.SetExtent(sliceIndex, sliceIndex, 0, data.eymax, 0, data.ezmax)
           val offset = computeOffset(0)
           data.sliceCorrectionTransform.Translate(+offset, 0, 0)
-        }
-        case Axis.Y => {
+        case Axis.Y =>
           data.slice.SetExtent(0, data.exmax, sliceIndex, sliceIndex, 0, data.ezmax)
           val offset = computeOffset(1)
           data.sliceCorrectionTransform.Translate(0, +offset, 0)
-        }
-        case Axis.Z => {
+        case Axis.Z =>
           data.slice.SetExtent(0, data.exmax, 0, data.eymax, sliceIndex, sliceIndex)
           val offset = computeOffset(2)
           data.sliceCorrectionTransform.Translate(0, 0, +offset)
-        }
       }
       data.sliceCorrectionTransform.Modified()
       data.slicePositionCorrector.Modified()

--- a/src/main/scala/scalismo/ui/rendering/actor/LandmarkActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/LandmarkActor.scala
@@ -18,7 +18,6 @@
 package scalismo.ui.rendering.actor
 
 import scalismo.geometry.{ SquareMatrix, _3D }
-import scalismo.ui.control.SlicingPosition.renderable
 import scalismo.ui.model.capabilities.Transformable
 import scalismo.ui.model.properties._
 import scalismo.ui.model.{ BoundingBox, LandmarkNode }

--- a/src/main/scala/scalismo/ui/rendering/actor/LandmarkActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/LandmarkActor.scala
@@ -29,7 +29,7 @@ import vtk._
 object LandmarkActor extends SimpleActorsFactory[LandmarkNode] {
   override def actorsFor(renderable: LandmarkNode, viewport: ViewportPanel): Option[Actors] = {
     viewport match {
-      case _3d: ViewportPanel3D => Some(new LandmarkActor3D(renderable))
+      case _: ViewportPanel3D => Some(new LandmarkActor3D(renderable))
       case _2d: ViewportPanel2D => Some(new LandmarkActor2D(renderable, _2d))
     }
   }

--- a/src/main/scala/scalismo/ui/rendering/actor/LandmarkActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/LandmarkActor.scala
@@ -63,7 +63,7 @@ trait LandmarkActor extends ActorColor with ActorOpacity with ActorSceneNode {
     case _ =>
   }
 
-  protected def rerender(geometryChanged: Boolean) = {
+  protected def rerender(geometryChanged: Boolean): Unit = {
     if (geometryChanged) {
       val (xRadius, yRadius, zRadius) = {
         val r = sceneNode.uncertainty.value.sigmas.toArray

--- a/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
@@ -166,7 +166,7 @@ trait MeshActor[R <: MeshRenderable] extends SinglePolyDataActor with ActorOpaci
   // this is invoked from within the rerender method, if the geometry has changed.
   protected def onGeometryChanged(): Unit
 
-  protected def rerender(geometryChanged: Boolean) = {
+  protected def rerender(geometryChanged: Boolean): Unit = {
     if (geometryChanged) {
       polydata = meshToPolyData(Some(polydata))
       onGeometryChanged()
@@ -276,7 +276,7 @@ abstract class MeshActor3D[R <: MeshRenderable](override val renderable: R) exte
     mapper.SetInputConnection(normals.GetOutputPort())
   }
 
-  override protected def onGeometryChanged() = {
+  override protected def onGeometryChanged(): Unit = {
     normals.RemoveAllInputs()
     normals.SetInputData(polydata)
     normals.Update()

--- a/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
@@ -19,11 +19,11 @@ package scalismo.ui.rendering.actor
 
 import scalismo.geometry._3D
 import scalismo.mesh.{ LineMesh, ScalarMeshField, TriangleMesh, VertexColorMesh3D }
+import scalismo.ui.model._
 import scalismo.ui.model.capabilities.Transformable
 import scalismo.ui.model.properties._
-import scalismo.ui.model._
 import scalismo.ui.rendering.Caches
-import scalismo.ui.rendering.Caches.{ FastCachingVertexColorMesh, FastCachingTriangleMesh }
+import scalismo.ui.rendering.Caches.{ FastCachingTriangleMesh, FastCachingVertexColorMesh }
 import scalismo.ui.rendering.actor.MeshActor.MeshRenderable
 import scalismo.ui.rendering.actor.mixin._
 import scalismo.ui.rendering.util.VtkUtil
@@ -233,6 +233,7 @@ trait VertexColorMeshActor extends MeshActor[MeshRenderable.VertexColorMeshRende
       pd.GetPointData().SetScalars(vtkColors)
       pd
     }
+
     Caches.VertexColorMeshCache.getOrCreate(FastCachingVertexColorMesh(renderable.colorMesh), colorMeshToVtkPd(renderable.colorMesh))
   }
 }

--- a/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
@@ -223,7 +223,7 @@ trait VertexColorMeshActor extends MeshActor[MeshRenderable.VertexColorMeshRende
 
       val pd = MeshConversion.meshToVtkPolyData(colorMesh.shape)
       val vtkColors = new vtkUnsignedCharArray()
-      vtkColors.SetNumberOfComponents(3);
+      vtkColors.SetNumberOfComponents(3)
       vtkColors.SetName("RGB")
 
       for (id <- colorMesh.shape.pointSet.pointIds) {

--- a/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
@@ -18,18 +18,18 @@
 package scalismo.ui.rendering.actor
 
 import scalismo.geometry._3D
-import scalismo.mesh.{LineMesh, ScalarMeshField, TriangleMesh, VertexColorMesh3D}
+import scalismo.mesh.{ LineMesh, ScalarMeshField, TriangleMesh, VertexColorMesh3D }
 import scalismo.ui.model.capabilities.Transformable
 import scalismo.ui.model.properties._
 import scalismo.ui.model._
 import scalismo.ui.rendering.Caches
-import scalismo.ui.rendering.Caches.{FastCachingVertexColorMesh, FastCachingTriangleMesh}
+import scalismo.ui.rendering.Caches.{ FastCachingVertexColorMesh, FastCachingTriangleMesh }
 import scalismo.ui.rendering.actor.MeshActor.MeshRenderable
 import scalismo.ui.rendering.actor.mixin._
 import scalismo.ui.rendering.util.VtkUtil
-import scalismo.ui.view.{ViewportPanel, ViewportPanel2D, ViewportPanel3D}
+import scalismo.ui.view.{ ViewportPanel, ViewportPanel2D, ViewportPanel3D }
 import scalismo.utils.MeshConversion
-import vtk.{vtkPolyData, vtkUnsignedCharArray}
+import vtk.{ vtkPolyData, vtkUnsignedCharArray }
 
 object TriangleMeshActor extends SimpleActorsFactory[TriangleMeshNode] {
 
@@ -68,7 +68,6 @@ object VertexColorMeshActor extends SimpleActorsFactory[VertexColorMeshNode] {
     }
   }
 }
-
 
 object MeshActor {
 
@@ -112,7 +111,6 @@ object MeshActor {
 
       def colorMesh = node.transformedSource
     }
-
 
     class ScalarMeshFieldRenderable(override val node: ScalarMeshFieldNode) extends MeshRenderable {
 
@@ -217,28 +215,27 @@ trait TriangleMeshActor extends MeshActor[MeshRenderable.TriangleMeshRenderable]
 
 trait VertexColorMeshActor extends MeshActor[MeshRenderable.VertexColorMeshRenderable] {
 
-    override def renderable: MeshRenderable.VertexColorMeshRenderable
+  override def renderable: MeshRenderable.VertexColorMeshRenderable
 
-    override protected def meshToPolyData(template: Option[vtkPolyData]): vtkPolyData = {
+  override protected def meshToPolyData(template: Option[vtkPolyData]): vtkPolyData = {
 
-      def colorMeshToVtkPd(colorMesh : VertexColorMesh3D) : vtkPolyData = {
+    def colorMeshToVtkPd(colorMesh: VertexColorMesh3D): vtkPolyData = {
 
-        val pd = MeshConversion.meshToVtkPolyData(colorMesh.shape)
-        val vtkColors = new vtkUnsignedCharArray()
-        vtkColors.SetNumberOfComponents(3);
-        vtkColors.SetName("RGB")
+      val pd = MeshConversion.meshToVtkPolyData(colorMesh.shape)
+      val vtkColors = new vtkUnsignedCharArray()
+      vtkColors.SetNumberOfComponents(3);
+      vtkColors.SetName("RGB")
 
-        for (id <- colorMesh.shape.pointSet.pointIds) {
-          val color = colorMesh.color(id)
-          vtkColors.InsertNextTuple3((color.r * 255).toShort, (color.g * 255).toShort, (color.b * 255).toShort)
-        }
-        pd.GetPointData().SetScalars(vtkColors)
-        pd
+      for (id <- colorMesh.shape.pointSet.pointIds) {
+        val color = colorMesh.color(id)
+        vtkColors.InsertNextTuple3((color.r * 255).toShort, (color.g * 255).toShort, (color.b * 255).toShort)
       }
-      Caches.VertexColorMeshCache.getOrCreate(FastCachingVertexColorMesh(renderable.colorMesh), colorMeshToVtkPd(renderable.colorMesh))
+      pd.GetPointData().SetScalars(vtkColors)
+      pd
     }
+    Caches.VertexColorMeshCache.getOrCreate(FastCachingVertexColorMesh(renderable.colorMesh), colorMeshToVtkPd(renderable.colorMesh))
+  }
 }
-
 
 trait LineMeshActor extends MeshActor[MeshRenderable.LineMeshRenderable] with ActorColor with ActorLineWidth {
   override def renderable: MeshRenderable.LineMeshRenderable
@@ -264,9 +261,6 @@ trait ScalarMeshFieldActor extends MeshActor[MeshRenderable.ScalarMeshFieldRende
   }
 
 }
-
-
-
 
 abstract class MeshActor3D[R <: MeshRenderable](override val renderable: R) extends MeshActor[R] {
 

--- a/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
@@ -35,7 +35,7 @@ object TriangleMeshActor extends SimpleActorsFactory[TriangleMeshNode] {
 
   override def actorsFor(renderable: TriangleMeshNode, viewport: ViewportPanel): Option[Actors] = {
     viewport match {
-      case _3d: ViewportPanel3D => Some(new TriangleMeshActor3D(renderable))
+      case _: ViewportPanel3D => Some(new TriangleMeshActor3D(renderable))
       case _2d: ViewportPanel2D => Some(new TriangleMeshActor2D(renderable, _2d))
     }
   }
@@ -45,7 +45,7 @@ object ScalarMeshFieldActor extends SimpleActorsFactory[ScalarMeshFieldNode] {
 
   override def actorsFor(renderable: ScalarMeshFieldNode, viewport: ViewportPanel): Option[Actors] = {
     viewport match {
-      case _3d: ViewportPanel3D => Some(new ScalarMeshFieldActor3D(renderable))
+      case _: ViewportPanel3D => Some(new ScalarMeshFieldActor3D(renderable))
       case _2d: ViewportPanel2D => Some(new ScalarMeshFieldActor2D(renderable, _2d))
     }
   }
@@ -54,7 +54,7 @@ object ScalarMeshFieldActor extends SimpleActorsFactory[ScalarMeshFieldNode] {
 object LineMeshActor extends SimpleActorsFactory[LineMeshNode] {
   override def actorsFor(renderable: LineMeshNode, viewport: ViewportPanel): Option[Actors] = {
     viewport match {
-      case _3d: ViewportPanel3D => Some(new LineMeshActor3D(renderable))
+      case _: ViewportPanel3D => Some(new LineMeshActor3D(renderable))
       case _2d: ViewportPanel2D => Some(new LineMeshActor2D(renderable, _2d))
     }
   }
@@ -63,7 +63,7 @@ object LineMeshActor extends SimpleActorsFactory[LineMeshNode] {
 object VertexColorMeshActor extends SimpleActorsFactory[VertexColorMeshNode] {
   override def actorsFor(renderable: VertexColorMeshNode, viewport: ViewportPanel): Option[Actors] = {
     viewport match {
-      case _3d: ViewportPanel3D => Some(new VertexColorMeshActor3D(renderable))
+      case _: ViewportPanel3D => Some(new VertexColorMeshActor3D(renderable))
       case _2d: ViewportPanel2D => Some(new VertexColorMeshActor2D(renderable, _2d))
     }
   }

--- a/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/MeshActor.scala
@@ -29,7 +29,7 @@ import scalismo.ui.rendering.actor.mixin._
 import scalismo.ui.rendering.util.VtkUtil
 import scalismo.ui.view.{ ViewportPanel, ViewportPanel2D, ViewportPanel3D }
 import scalismo.utils.MeshConversion
-import vtk.{ vtkPolyData, vtkUnsignedCharArray }
+import vtk.{ vtkPolyData, vtkPolyDataNormals, vtkUnsignedCharArray }
 
 object TriangleMeshActor extends SimpleActorsFactory[TriangleMeshNode] {
 
@@ -109,7 +109,7 @@ object MeshActor {
 
       override def lineWidth: LineWidthProperty = node.lineWidth
 
-      def colorMesh = node.transformedSource
+      def colorMesh: VertexColorMesh3D = node.transformedSource
     }
 
     class ScalarMeshFieldRenderable(override val node: ScalarMeshFieldNode) extends MeshRenderable {
@@ -248,7 +248,7 @@ trait LineMeshActor extends MeshActor[MeshRenderable.LineMeshRenderable] with Ac
     MeshConversion.lineMeshToVTKPolyData(renderable.mesh, template)
   }
 
-  override def lineWidth = renderable.lineWidth
+  override def lineWidth: LineWidthProperty = renderable.lineWidth
 
 }
 
@@ -267,7 +267,7 @@ abstract class MeshActor3D[R <: MeshRenderable](override val renderable: R) exte
 
   // not declaring this as lazy causes all sorts of weird VTK errors, probably because the methods which use
   // it are invoked from the superclass constructor (at which time this class is not necessarily fully initialized)(?)
-  lazy val normals = new vtk.vtkPolyDataNormals() {
+  private lazy val normals: vtkPolyDataNormals = new vtk.vtkPolyDataNormals() {
     ComputePointNormalsOn()
     ComputeCellNormalsOff()
   }

--- a/src/main/scala/scalismo/ui/rendering/actor/PointCloudActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/PointCloudActor.scala
@@ -45,7 +45,7 @@ trait PointCloudActor extends SinglePolyDataActor with ActorOpacity with ActorCo
 
   lazy val sphere = new vtkSphereSource
 
-  def transformedPoints = new vtkPoints {
+  private def transformedPoints: vtkPoints = new vtkPoints {
     sceneNode.transformedSource.foreach { point =>
       InsertNextPoint(point(0), point(1), point(2))
     }
@@ -53,7 +53,7 @@ trait PointCloudActor extends SinglePolyDataActor with ActorOpacity with ActorCo
 
   lazy val polydata = new vtkPolyData
 
-  lazy val glyph = new vtkGlyph3D {
+  protected lazy val glyph: vtkGlyph3D = new vtkGlyph3D {
     SetSourceConnection(sphere.GetOutputPort)
     SetInputData(polydata)
   }

--- a/src/main/scala/scalismo/ui/rendering/actor/PointCloudActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/PointCloudActor.scala
@@ -58,7 +58,7 @@ trait PointCloudActor extends SinglePolyDataActor with ActorOpacity with ActorCo
     SetInputData(polydata)
   }
 
-  def rerender(geometryChanged: Boolean) = {
+  def rerender(geometryChanged: Boolean): Unit = {
     if (geometryChanged) {
       polydata.SetPoints(transformedPoints)
     }

--- a/src/main/scala/scalismo/ui/rendering/actor/PointCloudActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/PointCloudActor.scala
@@ -28,7 +28,7 @@ import vtk.{ vtkGlyph3D, vtkPoints, vtkPolyData, vtkSphereSource }
 object PointCloudActor extends SimpleActorsFactory[PointCloudNode] {
   override def actorsFor(renderable: PointCloudNode, viewport: ViewportPanel): Option[Actors] = {
     viewport match {
-      case _3d: ViewportPanel3D => Some(new PointCloudActor3D(renderable))
+      case _: ViewportPanel3D => Some(new PointCloudActor3D(renderable))
       case _2d: ViewportPanel2D => Some(new PointCloudActor2D(renderable, _2d))
     }
   }

--- a/src/main/scala/scalismo/ui/rendering/actor/ScalarFieldActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/ScalarFieldActor.scala
@@ -49,13 +49,13 @@ trait ScalarFieldActor extends SinglePolyDataActor with ActorOpacity with ActorS
 
   lazy val sphere = new vtkSphereSource
 
-  def transformedPoints = new vtkPoints {
+  def transformedPoints: vtkPoints = new vtkPoints {
     sceneNode.transformedSource.domain.points.foreach { point =>
       InsertNextPoint(point(0), point(1), point(2))
     }
   }
 
-  lazy val polydata = {
+  protected lazy val polydata = {
     // Hack alert! We create a triangle mesh with empty cells and built from it a scalarMeshData.
     // In this way we can use the conversion utilities and have colors for free
 
@@ -65,7 +65,7 @@ trait ScalarFieldActor extends SinglePolyDataActor with ActorOpacity with ActorS
     MeshConversion.scalarMeshFieldToVtkPolyData(smf)
   }
 
-  lazy val glyph = new vtkGlyph3D {
+  protected lazy val glyph: vtkGlyph3D = new vtkGlyph3D {
     SetSourceConnection(sphere.GetOutputPort)
     SetInputData(polydata)
     SetScaleModeToDataScalingOff()

--- a/src/main/scala/scalismo/ui/rendering/actor/ScalarFieldActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/ScalarFieldActor.scala
@@ -27,7 +27,7 @@ import scalismo.ui.rendering.actor.mixin._
 import scalismo.ui.rendering.util.VtkUtil
 import scalismo.ui.view.{ ViewportPanel, ViewportPanel2D, ViewportPanel3D }
 import scalismo.utils.MeshConversion
-import vtk.{ vtkGlyph3D, vtkPoints, vtkSphereSource }
+import vtk.{ vtkGlyph3D, vtkPoints, vtkPolyData, vtkSphereSource }
 
 object ScalarFieldActor extends SimpleActorsFactory[ScalarFieldNode] {
   override def actorsFor(renderable: ScalarFieldNode, viewport: ViewportPanel): Option[Actors] = {
@@ -55,7 +55,7 @@ trait ScalarFieldActor extends SinglePolyDataActor with ActorOpacity with ActorS
     }
   }
 
-  protected lazy val polydata = {
+  protected lazy val polydata: vtkPolyData = {
     // Hack alert! We create a triangle mesh with empty cells and built from it a scalarMeshData.
     // In this way we can use the conversion utilities and have colors for free
 

--- a/src/main/scala/scalismo/ui/rendering/actor/ScalarFieldActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/ScalarFieldActor.scala
@@ -32,7 +32,7 @@ import vtk.{ vtkGlyph3D, vtkPoints, vtkSphereSource }
 object ScalarFieldActor extends SimpleActorsFactory[ScalarFieldNode] {
   override def actorsFor(renderable: ScalarFieldNode, viewport: ViewportPanel): Option[Actors] = {
     viewport match {
-      case _3d: ViewportPanel3D => Some(new ScalarFieldActor3D(renderable))
+      case _: ViewportPanel3D => Some(new ScalarFieldActor3D(renderable))
       case _2d: ViewportPanel2D => Some(new ScalarFieldActor2D(renderable, _2d))
     }
   }

--- a/src/main/scala/scalismo/ui/rendering/actor/ScalarFieldActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/ScalarFieldActor.scala
@@ -71,7 +71,7 @@ trait ScalarFieldActor extends SinglePolyDataActor with ActorOpacity with ActorS
     SetScaleModeToDataScalingOff()
   }
 
-  def rerender(geometryChanged: Boolean) = {
+  def rerender(geometryChanged: Boolean): Unit = {
 
     if (geometryChanged) {
       polydata.SetPoints(transformedPoints)

--- a/src/main/scala/scalismo/ui/rendering/actor/TransformationGlyphActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/TransformationGlyphActor.scala
@@ -26,7 +26,7 @@ import vtk.vtkFloatArray
 object TransformationGlyphActor extends SimpleActorsFactory[TransformationGlyphNode] {
   override def actorsFor(renderable: TransformationGlyphNode, viewport: ViewportPanel): Option[Actors] = {
     viewport match {
-      case _3d: ViewportPanel3D => Some(new TransformationGlyphActor3D(renderable))
+      case _: ViewportPanel3D => Some(new TransformationGlyphActor3D(renderable))
       case _2d: ViewportPanel2D => Some(new TransformationGlyphActor2D(renderable, _2d))
     }
   }
@@ -51,7 +51,7 @@ trait TransformationGlyphActor extends VectorFieldActor {
     var maxNorm = 0.0
     var minNorm = Double.MaxValue
 
-    for ((vector, i) <- sceneNode.transformedSource.values.zipWithIndex) {
+    for ((vector, _) <- sceneNode.transformedSource.values.zipWithIndex) {
       val norm = vector.norm
       vectors.InsertNextTuple3(vector(0), vector(1), vector(2))
       scalars.InsertNextValue(norm)

--- a/src/main/scala/scalismo/ui/rendering/actor/TransformationGlyphActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/TransformationGlyphActor.scala
@@ -17,10 +17,10 @@
 
 package scalismo.ui.rendering.actor
 
+import scalismo.ui.model.TransformationGlyphNode
 import scalismo.ui.model.properties.NodeProperty.event.PropertyChanged
-import scalismo.ui.model.properties.{ ScalarRangeProperty, ScalarRange }
-import scalismo.ui.model.{ VectorFieldNode, TransformationGlyphNode }
-import scalismo.ui.view.{ ViewportPanel2D, ViewportPanel3D, ViewportPanel }
+import scalismo.ui.model.properties.ScalarRange
+import scalismo.ui.view.{ ViewportPanel, ViewportPanel2D, ViewportPanel3D }
 import vtk.vtkFloatArray
 
 object TransformationGlyphActor extends SimpleActorsFactory[TransformationGlyphNode] {

--- a/src/main/scala/scalismo/ui/rendering/actor/TransformationGlyphActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/TransformationGlyphActor.scala
@@ -36,7 +36,7 @@ trait TransformationGlyphActor extends VectorFieldActor {
 
   override def sceneNode: TransformationGlyphNode
 
-  override def rerender(geometryChanged: Boolean) = {
+  override def rerender(geometryChanged: Boolean): Unit = {
 
     sceneNode.transformedSource
 

--- a/src/main/scala/scalismo/ui/rendering/actor/TransformationGlyphActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/TransformationGlyphActor.scala
@@ -77,4 +77,5 @@ trait TransformationGlyphActor extends VectorFieldActor {
 }
 
 class TransformationGlyphActor3D(override val sceneNode: TransformationGlyphNode) extends VectorFieldActor3D(sceneNode) with TransformationGlyphActor
+
 class TransformationGlyphActor2D(override val sceneNode: TransformationGlyphNode, viewport: ViewportPanel2D) extends VectorFieldActor2D(sceneNode, viewport) with TransformationGlyphActor

--- a/src/main/scala/scalismo/ui/rendering/actor/TransformationGlyphActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/TransformationGlyphActor.scala
@@ -48,7 +48,7 @@ trait TransformationGlyphActor extends VectorFieldActor {
       SetNumberOfComponents(3)
     }
 
-    var maxNorm = 0.0;
+    var maxNorm = 0.0
     var minNorm = Double.MaxValue
 
     for ((vector, i) <- sceneNode.transformedSource.values.zipWithIndex) {

--- a/src/main/scala/scalismo/ui/rendering/actor/VectorFieldActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/VectorFieldActor.scala
@@ -85,7 +85,7 @@ trait VectorFieldActor extends SinglePolyDataActor with ActorOpacity with ActorS
   mapper.SetInputConnection(glyph.GetOutputPort)
   mapper.ScalarVisibilityOn()
 
-  def rerender(geometryChanged: Boolean) = {
+  def rerender(geometryChanged: Boolean): Unit = {
     arrow.Modified()
     glyph.Update()
     glyph.Modified()

--- a/src/main/scala/scalismo/ui/rendering/actor/VectorFieldActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/VectorFieldActor.scala
@@ -28,7 +28,7 @@ import vtk._
 object VectorFieldActor extends SimpleActorsFactory[VectorFieldNode] {
   override def actorsFor(renderable: VectorFieldNode, viewport: ViewportPanel): Option[Actors] = {
     viewport match {
-      case _3d: ViewportPanel3D => Some(new VectorFieldActor3D(renderable))
+      case _: ViewportPanel3D => Some(new VectorFieldActor3D(renderable))
       case _2d: ViewportPanel2D => Some(new VectorFieldActor2D(renderable, _2d))
     }
   }
@@ -56,7 +56,7 @@ trait VectorFieldActor extends SinglePolyDataActor with ActorOpacity with ActorS
       SetNumberOfComponents(1)
     }
 
-    for (((point, vector), i) <- sceneNode.source.pointsWithValues.zipWithIndex) {
+    for (((point, vector), _) <- sceneNode.source.pointsWithValues.zipWithIndex) {
       points.InsertNextPoint(point(0), point(1), point(2))
       vectors.InsertNextTuple3(vector(0), vector(1), vector(2))
       scalars.InsertNextValue(vector.norm)
@@ -97,7 +97,7 @@ trait VectorFieldActor extends SinglePolyDataActor with ActorOpacity with ActorS
 
   reactions += {
     case Transformable.event.GeometryChanged(_) => rerender(true)
-    case NodeProperty.event.PropertyChanged(p) => rerender(false)
+    case NodeProperty.event.PropertyChanged(_) => rerender(false)
   }
 
   onInstantiated()

--- a/src/main/scala/scalismo/ui/rendering/actor/VectorFieldActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/VectorFieldActor.scala
@@ -17,10 +17,9 @@
 
 package scalismo.ui.rendering.actor
 
-import scalismo.ui.control.SlicingPosition.renderable
 import scalismo.ui.model.capabilities.Transformable
 import scalismo.ui.model.properties._
-import scalismo.ui.model.{ TransformationGlyphNode, BoundingBox, VectorFieldNode }
+import scalismo.ui.model.{ BoundingBox, VectorFieldNode }
 import scalismo.ui.rendering.actor.mixin._
 import scalismo.ui.rendering.util.VtkUtil
 import scalismo.ui.view.{ ViewportPanel, ViewportPanel2D, ViewportPanel3D }

--- a/src/main/scala/scalismo/ui/rendering/actor/VectorFieldActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/VectorFieldActor.scala
@@ -69,9 +69,9 @@ trait VectorFieldActor extends SinglePolyDataActor with ActorOpacity with ActorS
     }
   }
 
-  lazy val polydata = setupPolyData()
+  lazy val polydata: vtkPolyData = setupPolyData()
 
-  lazy val glyph = new vtkGlyph3D {
+  lazy val glyph: vtkGlyph3D = new vtkGlyph3D {
     SetSourceConnection(arrow.GetOutputPort)
     SetInputData(polydata)
     //    ScalingOn()

--- a/src/main/scala/scalismo/ui/rendering/actor/mixin/ActorColor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/mixin/ActorColor.scala
@@ -30,7 +30,7 @@ trait ActorColor extends SingleActor with ActorEvents {
     case NodeProperty.event.PropertyChanged(p) if p eq color => setAppearance()
   }
 
-  private def setAppearance() = {
+  private def setAppearance(): Unit = {
     GetProperty().SetColor(VtkUtil.colorToArray(color.value))
     actorChanged()
   }

--- a/src/main/scala/scalismo/ui/rendering/actor/mixin/ActorLineWidth.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/mixin/ActorLineWidth.scala
@@ -29,7 +29,7 @@ trait ActorLineWidth extends SingleActor with ActorEvents {
     case NodeProperty.event.PropertyChanged(p) if p eq lineWidth => setAppearance()
   }
 
-  private def setAppearance() = {
+  private def setAppearance(): Unit = {
     GetProperty().SetLineWidth(lineWidth.value)
     actorChanged()
   }

--- a/src/main/scala/scalismo/ui/rendering/actor/mixin/ActorOpacity.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/mixin/ActorOpacity.scala
@@ -29,7 +29,7 @@ trait ActorOpacity extends SingleActor with ActorEvents {
     case NodeProperty.event.PropertyChanged(p) if p eq opacity => setAppearance()
   }
 
-  private def setAppearance() = {
+  private def setAppearance(): Unit = {
     GetProperty().SetOpacity(opacity.value)
     actorChanged()
   }

--- a/src/main/scala/scalismo/ui/rendering/actor/mixin/ActorScalarRange.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/mixin/ActorScalarRange.scala
@@ -29,7 +29,7 @@ trait ActorScalarRange extends SinglePolyDataActor with ActorEvents {
     case NodeProperty.event.PropertyChanged(p) if p eq scalarRange => setAppearance()
   }
 
-  private def setAppearance() = {
+  private def setAppearance(): Unit = {
     mapper.SetScalarRange(scalarRange.value.cappedMinimum, scalarRange.value.cappedMaximum)
     mapper.Modified()
     actorChanged()

--- a/src/main/scala/scalismo/ui/rendering/internal/DeferredRendering.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/DeferredRendering.scala
@@ -20,8 +20,16 @@ package scalismo.ui.rendering.internal
 import java.util.{ Timer, TimerTask }
 
 object DeferredRendering {
-  // this should be almost unnoticeable for humans, but helps to prevent lags
-  // which would be caused by large amounts of render requests arriving at the same time.
+  /**
+   * Delay (in milliseconds) before actually rendering. Render requests
+   * are grouped and delayed by (at most) this amount of time.
+   * The delay should be almost unnoticeable for humans, but the grouping prevents lags
+   * that would otherwise be caused by large amounts of render requests arriving at the same time.
+   */
+  //noinspection VarCouldBeVal
+  /* This is a global variable that can be set by developers using the library.
+   * The "noinspection" comment suppresses a "var could be val" warning from IntelliJ IDEA.
+  */
   var DelayMs = 25
 }
 

--- a/src/main/scala/scalismo/ui/rendering/internal/DeferredRendering.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/DeferredRendering.scala
@@ -54,7 +54,7 @@ class DeferredRendering(operation: => Unit) extends Timer(true) {
     }
   }
 
-  def request() = skipped.synchronized {
+  def request(): Unit = skipped.synchronized {
     if (pending.isEmpty) {
       val task = new DeferredRenderTask
       pending = Some(task)

--- a/src/main/scala/scalismo/ui/rendering/internal/GLJPanelWithViewport.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/GLJPanelWithViewport.scala
@@ -19,7 +19,6 @@ package scalismo.ui.rendering.internal
 
 import javax.media.opengl.GLCapabilitiesImmutable
 import javax.media.opengl.awt.GLJPanel
-
 import scalismo.ui.view.ViewportPanel
 
 class GLJPanelWithViewport(val viewport: ViewportPanel, capabilities: GLCapabilitiesImmutable) extends GLJPanel(capabilities) {

--- a/src/main/scala/scalismo/ui/rendering/internal/RendererStateImplementation.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/RendererStateImplementation.scala
@@ -31,7 +31,7 @@ import vtk._
 class RendererStateImplementation(renderer: vtkRenderer, viewport: ViewportPanel) extends RendererState {
   val adapter = new CoordinateAdapter
 
-  val cellPicker = new vtkCellPicker {
+  private val cellPicker: vtkCellPicker = new vtkCellPicker {
     PickFromListOff()
     // This is needed so that 2D sliced actors can also be picked.
     // (At the default tolerance of 1e-6, it's virtually impossible to

--- a/src/main/scala/scalismo/ui/rendering/internal/RendererStateImplementation.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/RendererStateImplementation.scala
@@ -117,6 +117,8 @@ class RendererStateImplementation(renderer: vtkRenderer, viewport: ViewportPanel
       val pointOption = {
         val point: Point3D = scalismo.geometry.Point[_3D](array)
         val bb = viewport.frame.sceneControl.slicingPosition.boundingBox
+        //IntelliJ IDEA hint: don't complain, your suggested alternative is less understandable
+        //noinspection IfElseToFilterdOption
         if (bb.contains(point)) Some(point) else None
       }
       PointAndProp(pointOption, None)

--- a/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
@@ -25,7 +25,7 @@ import scalismo.ui.view.ViewportPanel
 import vtk._
 
 /**
- * This is essentially a Scala re-implementation based on [[vtk.rendering.jogl.vtkJoglPanelComponent]].
+ * This is essentially a Scala re-implementation based on `vtk.rendering.jogl.vtkJoglPanelComponent`.
  * It includes a couple of bugfixes and extensions.
  */
 class RenderingComponent(viewport: ViewportPanel) extends vtk.rendering.vtkComponent[GLJPanel] {

--- a/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
@@ -115,13 +115,13 @@ class RenderingComponent(viewport: ViewportPanel) extends vtk.rendering.vtkCompo
 
   ////// helper methods
 
-  private def executeLocked(block: => Unit) = {
+  private def executeLocked(block: => Unit): Unit = {
     lock.lock()
     block
     lock.unlock()
   }
 
-  private def executeInterruptibly(block: => Unit) = {
+  private def executeInterruptibly(block: => Unit): Unit = {
     try {
       lock.lockInterruptibly()
       block

--- a/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
@@ -18,9 +18,9 @@
 package scalismo.ui.rendering.internal
 
 import java.util.concurrent.locks.ReentrantLock
+
 import javax.media.opengl.awt.GLJPanel
 import javax.media.opengl.{ GLAutoDrawable, GLCapabilities, GLEventListener, GLProfile }
-
 import scalismo.ui.view.ViewportPanel
 import vtk._
 

--- a/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
@@ -126,7 +126,7 @@ class RenderingComponent(viewport: ViewportPanel) extends vtk.rendering.vtkCompo
       lock.lockInterruptibly()
       block
     } catch {
-      case e: InterruptedException => // nothing we can do
+      case _: InterruptedException => // nothing we can do
     } finally {
       lock.unlock()
     }

--- a/src/main/scala/scalismo/ui/resources/icons/BundledIcon.scala
+++ b/src/main/scala/scalismo/ui/resources/icons/BundledIcon.scala
@@ -17,8 +17,9 @@
 
 package scalismo.ui.resources.icons
 
-import java.awt.Color
+import java.awt.{ Color, Image }
 
+import javax.swing.ImageIcon
 import jiconfont.icons.{ Elusive, Entypo, FontAwesome }
 import scalismo.ui.resources.icons.FontIcon.awesome
 import scalismo.ui.resources.icons.png.PngIconResource
@@ -27,46 +28,46 @@ object BundledIcon {
 
   // This is an image (as opposed to an icon), because that's what Java Swing wants.
   // It's a 128x128 image that should hopefully be scaled according to the platform.
-  lazy val AppIcon = PngIconResource.load("app-icon.png").getImage
+  lazy val AppIcon: Image = PngIconResource.load("app-icon.png").getImage
 
-  lazy val Fallback = FontIcon.load(FontAwesome.BOLT)
+  lazy val Fallback: FontIcon = FontIcon.load(FontAwesome.BOLT)
 
   // this is relatively heavy, and seldomly needed, so we don't create a val.
-  def Logo = PngIconResource.load("logo.png")
+  def Logo: ImageIcon = PngIconResource.load("logo.png")
 
   // basic icons
-  lazy val Information = FontIcon.load(FontAwesome.INFO_CIRCLE, color = Color.BLUE.darker())
-  lazy val Warning = FontIcon.load(FontAwesome.EXCLAMATION_TRIANGLE, color = Color.ORANGE)
-  lazy val Error = FontIcon.load(FontAwesome.TIMES_CIRCLE, color = Color.RED.darker())
-  lazy val Question = FontIcon.load(FontAwesome.QUESTION_CIRCLE, color = Color.BLUE.darker())
+  lazy val Information: FontIcon = FontIcon.load(FontAwesome.INFO_CIRCLE, color = Color.BLUE.darker())
+  lazy val Warning: FontIcon = FontIcon.load(FontAwesome.EXCLAMATION_TRIANGLE, color = Color.ORANGE)
+  lazy val Error: FontIcon = FontIcon.load(FontAwesome.TIMES_CIRCLE, color = Color.RED.darker())
+  lazy val Question: FontIcon = FontIcon.load(FontAwesome.QUESTION_CIRCLE, color = Color.BLUE.darker())
 
   // toolbar, menu, or other general-purpose icons
-  lazy val Center = FontIcon.load(FontAwesome.DOT_CIRCLE_O)
-  lazy val Smiley = FontIcon.load(FontAwesome.SMILE_O)
-  lazy val Reset = FontIcon.load(FontAwesome.UNDO)
-  lazy val Screenshot = FontIcon.load(FontAwesome.CAMERA)
-  lazy val Remove = FontIcon.load(awesome('\uf00d'))
-  lazy val Save = FontIcon.load(awesome('\uf0c7'))
-  lazy val Load = FontIcon.load(FontAwesome.FILE_O)
-  lazy val Name = FontIcon.load(FontAwesome.FONT)
-  lazy val Exit = FontIcon.load(Entypo.LOGOUT)
-  lazy val Scale = FontIcon.load(Entypo.RESIZE_FULL)
-  lazy val Perspective = FontIcon.load(Elusive.GLASSES)
-  lazy val Visible = FontIcon.load(Elusive.EYE_OPEN)
-  lazy val Invisible = FontIcon.load(Elusive.EYE_CLOSE)
-  lazy val Background = FontIcon.load(Entypo.ADJUST)
+  lazy val Center: FontIcon = FontIcon.load(FontAwesome.DOT_CIRCLE_O)
+  lazy val Smiley: FontIcon = FontIcon.load(FontAwesome.SMILE_O)
+  lazy val Reset: FontIcon = FontIcon.load(FontAwesome.UNDO)
+  lazy val Screenshot: FontIcon = FontIcon.load(FontAwesome.CAMERA)
+  lazy val Remove: FontIcon = FontIcon.load(awesome('\uf00d'))
+  lazy val Save: FontIcon = FontIcon.load(awesome('\uf0c7'))
+  lazy val Load: FontIcon = FontIcon.load(FontAwesome.FILE_O)
+  lazy val Name: FontIcon = FontIcon.load(FontAwesome.FONT)
+  lazy val Exit: FontIcon = FontIcon.load(Entypo.LOGOUT)
+  lazy val Scale: FontIcon = FontIcon.load(Entypo.RESIZE_FULL)
+  lazy val Perspective: FontIcon = FontIcon.load(Elusive.GLASSES)
+  lazy val Visible: FontIcon = FontIcon.load(Elusive.EYE_OPEN)
+  lazy val Invisible: FontIcon = FontIcon.load(Elusive.EYE_CLOSE)
+  lazy val Background: FontIcon = FontIcon.load(Entypo.ADJUST)
 
   // general SceneNode icons
-  lazy val Scene = FontIcon.load(FontAwesome.HOME)
-  lazy val Group = FontIcon.load(FontAwesome.CUBES)
-  lazy val FolderOpen = FontIcon.load(FontAwesome.FOLDER_OPEN_O)
-  lazy val FolderClosed = FontIcon.load(FontAwesome.FOLDER_O)
+  lazy val Scene: FontIcon = FontIcon.load(FontAwesome.HOME)
+  lazy val Group: FontIcon = FontIcon.load(FontAwesome.CUBES)
+  lazy val FolderOpen: FontIcon = FontIcon.load(FontAwesome.FOLDER_OPEN_O)
+  lazy val FolderClosed: FontIcon = FontIcon.load(FontAwesome.FOLDER_O)
 
   // particular SceneNode classes
-  lazy val Mesh = FontIcon.load(FontAwesome.DIAMOND)
-  lazy val PointCloud = FontIcon.load(awesome('\uf1e3'))
-  lazy val Landmark = FontIcon.load(FontAwesome.CROSSHAIRS)
-  lazy val Transformation = FontIcon.load(FontAwesome.ARROW_CIRCLE_RIGHT)
-  lazy val Image = FontIcon.load(FontAwesome.PICTURE_O)
+  lazy val Mesh: FontIcon = FontIcon.load(FontAwesome.DIAMOND)
+  lazy val PointCloud: FontIcon = FontIcon.load(awesome('\uf1e3'))
+  lazy val Landmark: FontIcon = FontIcon.load(FontAwesome.CROSSHAIRS)
+  lazy val Transformation: FontIcon = FontIcon.load(FontAwesome.ARROW_CIRCLE_RIGHT)
+  lazy val Image: FontIcon = FontIcon.load(FontAwesome.PICTURE_O)
 
 }

--- a/src/main/scala/scalismo/ui/resources/icons/FontIcon.scala
+++ b/src/main/scala/scalismo/ui/resources/icons/FontIcon.scala
@@ -20,8 +20,8 @@ package scalismo.ui.resources.icons
 import java.awt._
 import java.awt.geom.Rectangle2D
 import java.awt.image.BufferedImage
-import javax.swing.ImageIcon
 
+import javax.swing.ImageIcon
 import jiconfont.icons.{ Elusive, Entypo, FontAwesome }
 import jiconfont.{ IconCode, IconFont }
 import scalismo.ui.view.util.Constants
@@ -36,6 +36,7 @@ object FontIcon {
     def createTuple(iconFont: IconFont): (String, Font) = {
       (iconFont.getFontFamily, Font.createFont(Font.TRUETYPE_FONT, iconFont.getFontInputStream))
     }
+
     // this is where a new supported icon font would have to be added.
     val iconFonts = Seq(FontAwesome.getIconFont, Entypo.getIconFont, Elusive.getIconFont)
     iconFonts.map(createTuple).toMap

--- a/src/main/scala/scalismo/ui/resources/icons/ScalableIcon.scala
+++ b/src/main/scala/scalismo/ui/resources/icons/ScalableIcon.scala
@@ -18,7 +18,6 @@
 package scalismo.ui.resources.icons
 
 import javax.swing.Icon
-
 import scalismo.ui.view.util.{ Constants, ScalableUI }
 
 trait ScalableIcon extends Icon {

--- a/src/main/scala/scalismo/ui/settings/PersistentSettings.scala
+++ b/src/main/scala/scalismo/ui/settings/PersistentSettings.scala
@@ -113,7 +113,7 @@ class PersistentSettings(val settingsFile: SettingsFile) {
     sf.getValues(key)
   }
 
-  private def doSet(key: String, vals: List[String]) = {
+  private def doSet(key: String, vals: List[String]): Unit = {
     val sf: SettingsFile = settingsFile
     sf.setValues(key, vals)
   }

--- a/src/main/scala/scalismo/ui/settings/PersistentSettings.scala
+++ b/src/main/scala/scalismo/ui/settings/PersistentSettings.scala
@@ -67,7 +67,7 @@ class PersistentSettings(val settingsFile: SettingsFile) {
   def getList[A: TypeTag: Codec](key: String): Option[List[A]] = {
 
     Try(doGet(key)) match {
-      case Failure(error) => None
+      case Failure(_) => None
       case Success(r) => Some(r.map(s => implicitly[Codec[A]].fromString(s)))
     }
   }
@@ -103,7 +103,7 @@ class PersistentSettings(val settingsFile: SettingsFile) {
 
   def setList[A: TypeTag: Codec](key: String, values: List[A]): Try[Unit] = {
     Try(doSet(key, values.map(v => implicitly[Codec[A]].toString(v)))) match {
-      case Success(r) => Success(())
+      case Success(_) => Success(())
       case Failure(oops) => Failure(oops)
     }
   }

--- a/src/main/scala/scalismo/ui/settings/SettingsFile.scala
+++ b/src/main/scala/scalismo/ui/settings/SettingsFile.scala
@@ -39,7 +39,7 @@ class SettingsFile(directory: File, name: String) {
     } else Nil
   }
 
-  private def writeFile(values: List[String]) = {
+  private def writeFile(values: List[String]): Unit = {
     if (!file.exists) {
       if (!file.getParentFile.exists) {
         file.getParentFile.mkdirs()

--- a/src/main/scala/scalismo/ui/settings/SettingsFile.scala
+++ b/src/main/scala/scalismo/ui/settings/SettingsFile.scala
@@ -98,36 +98,36 @@ object SettingsFile {
 
   object Codec {
 
-    implicit val stringCodec = new Codec[String] {
-      override def fromString(s: String) = s
+    implicit val stringCodec: Codec[String] = new Codec[String] {
+      override def fromString(s: String): String = s
     }
 
-    implicit val booleanCodec = new Codec[Boolean] {
-      override def fromString(s: String) = java.lang.Boolean.parseBoolean(s)
+    implicit val booleanCodec: Codec[Boolean] = new Codec[Boolean] {
+      override def fromString(s: String): Boolean = java.lang.Boolean.parseBoolean(s)
     }
 
-    implicit val intCodec = new Codec[Int] {
-      override def fromString(s: String) = Integer.parseInt(s)
+    implicit val intCodec: Codec[Int] = new Codec[Int] {
+      override def fromString(s: String): Int = Integer.parseInt(s)
     }
 
-    implicit val longCodec = new Codec[Long] {
-      override def fromString(s: String) = java.lang.Long.parseLong(s)
+    implicit val longCodec: Codec[Long] = new Codec[Long] {
+      override def fromString(s: String): Long = java.lang.Long.parseLong(s)
     }
 
-    implicit val shortCodec = new Codec[Short] {
-      override def fromString(s: String) = java.lang.Short.parseShort(s)
+    implicit val shortCodec: Codec[Short] = new Codec[Short] {
+      override def fromString(s: String): Short = java.lang.Short.parseShort(s)
     }
 
-    implicit val byteCodec = new Codec[Byte] {
-      override def fromString(s: String) = java.lang.Byte.parseByte(s)
+    implicit val byteCodec: Codec[Byte] = new Codec[Byte] {
+      override def fromString(s: String): Byte = java.lang.Byte.parseByte(s)
     }
 
-    implicit val doubleCodec = new Codec[Double] {
-      override def fromString(s: String) = java.lang.Double.parseDouble(s)
+    implicit val doubleCodec: Codec[Double] = new Codec[Double] {
+      override def fromString(s: String): Double = java.lang.Double.parseDouble(s)
     }
 
-    implicit val floatCodec = new Codec[Float] {
-      override def fromString(s: String) = java.lang.Float.parseFloat(s)
+    implicit val floatCodec: Codec[Float] = new Codec[Float] {
+      override def fromString(s: String): Float = java.lang.Float.parseFloat(s)
     }
   }
 

--- a/src/main/scala/scalismo/ui/settings/SettingsFile.scala
+++ b/src/main/scala/scalismo/ui/settings/SettingsFile.scala
@@ -91,44 +91,39 @@ object SettingsFile {
    * @tparam A the type that can be (de)serialized
    */
   trait Codec[A] {
-    def toString(target: A): String = target.toString
+    def toString(value: A): String
 
     def fromString(s: String): A
   }
 
   object Codec {
 
-    implicit val stringCodec: Codec[String] = new Codec[String] {
-      override def fromString(s: String): String = s
+    /* Creates a codec using the default toString method to encode,
+     * and a given function to decode.
+     */
+    def apply[A](decode: String => A): Codec[A] = {
+      new Codec[A] {
+        override def toString(value: A): String = value.toString
+
+        override def fromString(s: String): A = decode(s)
+      }
     }
 
-    implicit val booleanCodec: Codec[Boolean] = new Codec[Boolean] {
-      override def fromString(s: String): Boolean = java.lang.Boolean.parseBoolean(s)
-    }
+    implicit val stringCodec: Codec[String] = Codec({ s: String => s })
 
-    implicit val intCodec: Codec[Int] = new Codec[Int] {
-      override def fromString(s: String): Int = Integer.parseInt(s)
-    }
+    implicit val booleanCodec: Codec[Boolean] = Codec(java.lang.Boolean.parseBoolean)
 
-    implicit val longCodec: Codec[Long] = new Codec[Long] {
-      override def fromString(s: String): Long = java.lang.Long.parseLong(s)
-    }
+    implicit val intCodec: Codec[Int] = Codec(Integer.parseInt)
 
-    implicit val shortCodec: Codec[Short] = new Codec[Short] {
-      override def fromString(s: String): Short = java.lang.Short.parseShort(s)
-    }
+    implicit val longCodec: Codec[Long] = Codec(java.lang.Long.parseLong)
 
-    implicit val byteCodec: Codec[Byte] = new Codec[Byte] {
-      override def fromString(s: String): Byte = java.lang.Byte.parseByte(s)
-    }
+    implicit val shortCodec: Codec[Short] = Codec(java.lang.Short.parseShort)
 
-    implicit val doubleCodec: Codec[Double] = new Codec[Double] {
-      override def fromString(s: String): Double = java.lang.Double.parseDouble(s)
-    }
+    implicit val byteCodec: Codec[Byte] = Codec(java.lang.Byte.parseByte)
 
-    implicit val floatCodec: Codec[Float] = new Codec[Float] {
-      override def fromString(s: String): Float = java.lang.Float.parseFloat(s)
-    }
+    implicit val doubleCodec: Codec[Double] = Codec(java.lang.Double.parseDouble)
+
+    implicit val floatCodec: Codec[Float] = Codec(java.lang.Float.parseFloat)
   }
 
 }

--- a/src/main/scala/scalismo/ui/util/Cache.scala
+++ b/src/main/scala/scalismo/ui/util/Cache.scala
@@ -20,6 +20,14 @@ package scalismo.ui.util
 import scala.collection.mutable
 
 object Cache {
+  /**
+   * Global flag to debug all cache operations.
+   */
+
+  //noinspection VarCouldBeVal
+  /* This is a global variable that can be set by developers using the library.
+   * The "noinspection" comment suppresses a "var could be val" warning from IntelliJ IDEA.
+   */
   var DebugAll = false
 }
 

--- a/src/main/scala/scalismo/ui/util/FileIoMetadata.scala
+++ b/src/main/scala/scalismo/ui/util/FileIoMetadata.scala
@@ -52,7 +52,7 @@ object FileIoMetadata {
     override val fileExtensions = List("vtk")
   }
 
-  val VertexColorMesh = new FileIoMetadata {
+  val VertexColorMesh: FileIoMetadata = new FileIoMetadata {
 
     override def fileExtensions: List[String] = List("ply")
 

--- a/src/main/scala/scalismo/ui/util/FileIoMetadata.scala
+++ b/src/main/scala/scalismo/ui/util/FileIoMetadata.scala
@@ -37,17 +37,17 @@ trait FileIoMetadata {
 
 object FileIoMetadata {
 
-  val Png = new FileIoMetadata {
+  val Png: FileIoMetadata = new FileIoMetadata {
     override val description = "PNG Image"
     override val fileExtensions = List("png")
   }
 
-  val TriangleMesh = new FileIoMetadata {
+  val TriangleMesh: FileIoMetadata = new FileIoMetadata {
     override val description = "Triangle Mesh"
     override val fileExtensions = List("stl", "vtk", "ply")
   }
 
-  val ScalarMeshField = new FileIoMetadata {
+  val ScalarMeshField: FileIoMetadata = new FileIoMetadata {
     override val description = "Scalar Mesh Field"
     override val fileExtensions = List("vtk")
   }
@@ -59,17 +59,17 @@ object FileIoMetadata {
     override def description: String = "Triangle Mesh with vertex color"
   }
 
-  val Image = new FileIoMetadata {
+  val Image: FileIoMetadata = new FileIoMetadata {
     override val description = "3D Image"
     override val fileExtensions = List("nii", "vtk")
   }
 
-  val Landmarks = new FileIoMetadata {
+  val Landmarks: FileIoMetadata = new FileIoMetadata {
     override val description = "Landmarks"
     override val fileExtensions = List("json", "csv")
   }
 
-  val StatisticalShapeModel = new FileIoMetadata {
+  val StatisticalShapeModel: FileIoMetadata = new FileIoMetadata {
     override val description = "Statistical Shape Model"
     override val fileExtensions = List("h5")
   }

--- a/src/main/scala/scalismo/ui/util/FileIoMetadata.scala
+++ b/src/main/scala/scalismo/ui/util/FileIoMetadata.scala
@@ -55,6 +55,7 @@ object FileIoMetadata {
   val VertexColorMesh = new FileIoMetadata {
 
     override def fileExtensions: List[String] = List("ply")
+
     override def description: String = "Triangle Mesh with vertex color"
   }
 

--- a/src/main/scala/scalismo/ui/util/ObjectId.scala
+++ b/src/main/scala/scalismo/ui/util/ObjectId.scala
@@ -18,7 +18,7 @@
 package scalismo.ui.util
 
 object ObjectId {
-  def of[T](thing: T) = {
+  def of[T](thing: T): String = {
     if (thing == null) "null" else thing.getClass.getName + "@" + thing.hashCode()
   }
 }

--- a/src/main/scala/scalismo/ui/view/NodePropertiesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodePropertiesPanel.scala
@@ -60,7 +60,7 @@ object NodePropertiesPanel {
   class Tabs extends Component with ScalismoPublisher {
     outer =>
     override lazy val peer: JTabbedPane = new JTabbedPane() with SuperMixin {
-      override def setSelectedIndex(index: Int) = {
+      override def setSelectedIndex(index: Int): Unit = {
         super.setSelectedIndex(index)
         if (getTabCount > index) {
           getTabComponentAt(index) match {
@@ -144,17 +144,17 @@ class NodePropertiesPanel(frame: ScalismoFrame) extends BorderPanel {
    */
   def handlers: List[PropertyPanel] = _handlers
 
-  def addHandler(handler: PropertyPanel) = {
+  def addHandler(handler: PropertyPanel): Unit = {
     _handlers ++= List(handler)
     cards.add(handler)
   }
 
-  def removeHandler(handler: PropertyPanel) = {
+  def removeHandler(handler: PropertyPanel): Unit = {
     _handlers = _handlers.filterNot(_ eq handler)
     cards.remove(handler)
   }
 
-  def setupHandlers() = {
+  def setupHandlers(): Unit = {
     // default implementation: instantiate all builtin providers.
     NodePropertiesPanel.BuiltinHandlers.foreach { constructor =>
       addHandler(constructor(frame))

--- a/src/main/scala/scalismo/ui/view/NodePropertiesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodePropertiesPanel.scala
@@ -18,8 +18,8 @@
 package scalismo.ui.view
 
 import java.awt.Dimension
-import javax.swing.{ JLabel, JTabbedPane }
 
+import javax.swing.{ JLabel, JTabbedPane }
 import scalismo.ui.event.ScalismoPublisher
 import scalismo.ui.view.NodePropertiesPanel.Tabs
 import scalismo.ui.view.NodePropertiesPanel.Tabs.event.TabChanged

--- a/src/main/scala/scalismo/ui/view/NodePropertiesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodePropertiesPanel.scala
@@ -162,7 +162,7 @@ class NodePropertiesPanel(frame: ScalismoFrame) extends BorderPanel {
   }
 
   // placeholder object that gets shown when nothing is to be shown :-)
-  val empty = new BorderPanel with CardPanel.ComponentWithUniqueId {
+  val empty: BorderPanel with CardPanel.ComponentWithUniqueId = new BorderPanel with CardPanel.ComponentWithUniqueId {
     val zero = new Dimension(0, 0)
     peer.setPreferredSize(zero)
     peer.setMinimumSize(zero)

--- a/src/main/scala/scalismo/ui/view/NodePropertiesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodePropertiesPanel.scala
@@ -173,11 +173,11 @@ class NodePropertiesPanel(frame: ScalismoFrame) extends BorderPanel {
   val tabs = new Tabs
 
   // actual content.
-  val cards = new CardPanel {
+  private val cards = new CardPanel {
     add(empty)
   }
 
-  val scroll = new ScrollPane() {
+  private val scroll = new ScrollPane() {
     contents = cards
     enabled = false
 

--- a/src/main/scala/scalismo/ui/view/NodesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodesPanel.scala
@@ -29,7 +29,7 @@ import scalismo.ui.model.properties.ColorProperty
 import scalismo.ui.resources.icons.{ BundledIcon, FontIcon, ScalableIcon }
 import scalismo.ui.util.NodeListFilters
 import scalismo.ui.view.NodesPanel.{ SceneNodeCellRenderer, ViewNode }
-import scalismo.ui.view.action.popup.{ ChildVisibilityAction, PopupAction, PopupActionWithOwnMenu }
+import scalismo.ui.view.action.popup.{ PopupAction, PopupActionWithOwnMenu }
 
 import scala.collection.JavaConversions.enumerationAsScalaIterator
 import scala.collection.immutable

--- a/src/main/scala/scalismo/ui/view/NodesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodesPanel.scala
@@ -291,7 +291,7 @@ class NodesPanel(val frame: ScalismoFrame) extends BorderPanel with NodeListFilt
     def nodeOrChildrenIfCollapsed(node: SceneNode): Seq[SceneNode] = {
       node match {
         case c: CollapsableView if c.isViewCollapsed => node.children.flatMap(nodeOrChildrenIfCollapsed)
-        case group: GroupNode if group.isGhost => Nil
+        case group: GroupNode if group.hidden => Nil
         case _ => List(node)
       }
     }

--- a/src/main/scala/scalismo/ui/view/NodesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodesPanel.scala
@@ -31,7 +31,7 @@ import scalismo.ui.util.NodeListFilters
 import scalismo.ui.view.NodesPanel.{ SceneNodeCellRenderer, ViewNode }
 import scalismo.ui.view.action.popup.{ PopupAction, PopupActionWithOwnMenu }
 
-import scala.collection.JavaConversions.enumerationAsScalaIterator
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.swing.{ BorderPanel, Component, ScrollPane }
 import scala.util.Try
@@ -220,7 +220,7 @@ class NodesPanel(val frame: ScalismoFrame) extends BorderPanel with NodeListFilt
     def findRecursive(currentNode: ViewNode): Option[ViewNode] = {
       if (currentNode.getUserObject eq node) Some(currentNode)
       else {
-        currentNode.children().foreach { child =>
+        currentNode.children().asScala.foreach { child =>
           findRecursive(child.asInstanceOf[ViewNode]) match {
             case found @ Some(_) => return found
             case _ =>
@@ -286,7 +286,7 @@ class NodesPanel(val frame: ScalismoFrame) extends BorderPanel with NodeListFilt
     // of that node's children.
 
     // don't replace this with a val, it has to be freshly evaluated every time
-    def viewChildren = view.children.map(_.asInstanceOf[ViewNode]).toList
+    def viewChildren = view.children.asScala.map(_.asInstanceOf[ViewNode]).toList
 
     def nodeOrChildrenIfCollapsed(node: SceneNode): Seq[SceneNode] = {
       node match {

--- a/src/main/scala/scalismo/ui/view/NodesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodesPanel.scala
@@ -138,7 +138,7 @@ class NodesPanel(val frame: ScalismoFrame) extends BorderPanel with NodeListFilt
   // being performed (i.e. tree is being programmatically modified)
   private var synchronizing = false
 
-  val mouseListener = new MouseAdapter() {
+  val mouseListener: MouseAdapter = new MouseAdapter() {
     override def mousePressed(event: MouseEvent): Unit = handle(event)
 
     override def mouseReleased(event: MouseEvent): Unit = handle(event)

--- a/src/main/scala/scalismo/ui/view/NodesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodesPanel.scala
@@ -184,7 +184,7 @@ class NodesPanel(val frame: ScalismoFrame) extends BorderPanel with NodeListFilt
     }
   }
 
-  var keyListener = new KeyAdapter {
+  val keyListener = new KeyAdapter {
     override def keyTyped(event: KeyEvent): Unit = {
       if (event.getKeyChar == '\u007f') {
         // delete

--- a/src/main/scala/scalismo/ui/view/NodesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodesPanel.scala
@@ -56,9 +56,8 @@ object NodesPanel {
     }
 
     object Icons {
-      val fallback = BundledIcon.Fallback.standardSized()
-      /* note: this uses the "closed" icon for leaves. */
 
+      /* note: this uses the "closed" icon for leaves. */
       private def closedIcon(node: SceneNode): Option[ScalableIcon] = {
         node match {
           case _: Scene => Some(BundledIcon.Scene)
@@ -130,7 +129,7 @@ object NodesPanel {
 }
 
 class NodesPanel(val frame: ScalismoFrame) extends BorderPanel with NodeListFilters {
-  val scene = frame.scene
+  private val scene = frame.scene
 
   val rootNode = new ViewNode(scene)
 
@@ -170,7 +169,7 @@ class NodesPanel(val frame: ScalismoFrame) extends BorderPanel with NodeListFilt
     }
   }
 
-  val selectionListener = new TreeSelectionListener {
+  private val selectionListener = new TreeSelectionListener {
     override def valueChanged(e: TreeSelectionEvent): Unit = {
       if (!synchronizing) {
         frame.selectedNodes = getSelectedSceneNodes
@@ -178,13 +177,13 @@ class NodesPanel(val frame: ScalismoFrame) extends BorderPanel with NodeListFilt
     }
   }
 
-  val componentListener = new ComponentAdapter {
+  private val componentListener = new ComponentAdapter {
     override def componentResized(e: ComponentEvent): Unit = {
       repaintTree()
     }
   }
 
-  val keyListener = new KeyAdapter {
+  private val keyListener = new KeyAdapter {
     override def keyTyped(event: KeyEvent): Unit = {
       if (event.getKeyChar == '\u007f') {
         // delete

--- a/src/main/scala/scalismo/ui/view/NodesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodesPanel.scala
@@ -48,7 +48,7 @@ object NodesPanel {
 
     class Icons(open: Icon, closed: Icon, leaf: Icon) {
       // the invocation context is a call to getTreeCellRendererComponent().
-      def apply() = {
+      def apply(): Unit = {
         setOpenIcon(open)
         setClosedIcon(closed)
         setLeafIcon(leaf)
@@ -139,11 +139,11 @@ class NodesPanel(val frame: ScalismoFrame) extends BorderPanel with NodeListFilt
   private var synchronizing = false
 
   val mouseListener = new MouseAdapter() {
-    override def mousePressed(event: MouseEvent) = handle(event)
+    override def mousePressed(event: MouseEvent): Unit = handle(event)
 
-    override def mouseReleased(event: MouseEvent) = handle(event)
+    override def mouseReleased(event: MouseEvent): Unit = handle(event)
 
-    def handle(event: MouseEvent) = {
+    def handle(event: MouseEvent): Unit = {
       if (event.isPopupTrigger) {
         val (x, y) = (event.getX, event.getY)
         pathToSceneNode(tree.getPathForLocation(x, y)).foreach { node =>
@@ -250,7 +250,7 @@ class NodesPanel(val frame: ScalismoFrame) extends BorderPanel with NodeListFilt
     }
   }
 
-  def setSelectedSceneNodes(nodes: immutable.Seq[SceneNode]) = {
+  def setSelectedSceneNodes(nodes: immutable.Seq[SceneNode]): Unit = {
     val paths = nodes.map(sceneNodeToPath).collect(definedOnly)
     if (paths.nonEmpty) {
       tree.setSelectionPaths(paths.toArray)

--- a/src/main/scala/scalismo/ui/view/ScalismoApplication.scala
+++ b/src/main/scala/scalismo/ui/view/ScalismoApplication.scala
@@ -22,7 +22,7 @@ import scalismo.ui.util.EdtUtil
 import scala.swing.SimpleSwingApplication
 
 /**
- * A Scalismo application is a [[SimpleSwingApplication]], having a [[ScalismoFrame]] as the top component, and using the [[ScalismoLookAndFeel]].
+ * A Scalismo application is a `scala.swing.SimpleSwingApplication`, having a [[ScalismoFrame]] as the top component, and using the [[ScalismoLookAndFeel]].
  *
  * This class takes care of initializing the Look and Feel, and setting up the frame with the command-line arguments.
  *

--- a/src/main/scala/scalismo/ui/view/ScalismoApplication.scala
+++ b/src/main/scala/scalismo/ui/view/ScalismoApplication.scala
@@ -34,13 +34,13 @@ class ScalismoApplication(frame: => ScalismoFrame, lookAndFeelClassName: String 
 
   override lazy val top = EdtUtil.onEdtWait(frame)
 
-  override def main(args: Array[String]) = {
+  override def main(args: Array[String]): Unit = {
     scalismo.initialize()
     ScalismoLookAndFeel.initializeWith(lookAndFeelClassName)
     super.main(args)
   }
 
-  override def startup(args: Array[String]) = {
+  override def startup(args: Array[String]): Unit = {
     top.setup(args)
     super.startup(args)
   }

--- a/src/main/scala/scalismo/ui/view/ScalismoApplication.scala
+++ b/src/main/scala/scalismo/ui/view/ScalismoApplication.scala
@@ -32,7 +32,7 @@ import scala.swing.SimpleSwingApplication
  */
 class ScalismoApplication(frame: => ScalismoFrame, lookAndFeelClassName: String = ScalismoLookAndFeel.DefaultLookAndFeelClassName) extends SimpleSwingApplication {
 
-  override lazy val top = EdtUtil.onEdtWait(frame)
+  override lazy val top: ScalismoFrame = EdtUtil.onEdtWait(frame)
 
   override def main(args: Array[String]): Unit = {
     scalismo.initialize()

--- a/src/main/scala/scalismo/ui/view/ScalismoFrame.scala
+++ b/src/main/scala/scalismo/ui/view/ScalismoFrame.scala
@@ -51,7 +51,7 @@ object ScalismoFrame {
  * a ScalismoFrame MUST be instantiated on the Swing EDT. The constructor will throw
  * an exception if this is not the case.
  *
- * @param scene a [[Scene]] object representing the model that the view uses.
+ * @param scene a [[scalismo.ui.model.Scene]] object representing the model that the view uses.
  * @see [[ScalismoApplication]]
  */
 class ScalismoFrame(val scene: Scene) extends MainFrame with ScalismoPublisher {

--- a/src/main/scala/scalismo/ui/view/ScalismoFrame.scala
+++ b/src/main/scala/scalismo/ui/view/ScalismoFrame.scala
@@ -21,17 +21,15 @@ import java.awt.Dimension
 
 import javax.swing.{ SwingUtilities, WindowConstants }
 import scalismo.ui.control.SceneControl
-import scalismo.ui.control.interactor.landmark.simple.SimpleLandmarkingInteractor
-import scalismo.ui.view.menu.ViewMenu.ShowBackgroundColorDialogItem
-
 import scalismo.ui.control.interactor.Interactor
+import scalismo.ui.control.interactor.landmark.simple.SimpleLandmarkingInteractor
 import scalismo.ui.event.{ Event, ScalismoPublisher }
 import scalismo.ui.model.{ Scene, SceneNode }
 import scalismo.ui.settings.GlobalSettings
 import scalismo.ui.view.ScalismoFrame.event.SelectedNodesChanged
 import scalismo.ui.view.menu.FileMenu.CloseFrameItem
 import scalismo.ui.view.menu.HelpMenu.ShowAboutDialogItem
-import scalismo.ui.view.menu.ViewMenu.{ PerspectiveMenu, ShowDisplayScalingDialogItem }
+import scalismo.ui.view.menu.ViewMenu.{ PerspectiveMenu, ShowBackgroundColorDialogItem, ShowDisplayScalingDialogItem }
 import scalismo.ui.view.menu.{ FileMenu, HelpMenu, ViewMenu }
 
 import scala.swing.{ BorderPanel, Component, MainFrame, MenuBar }

--- a/src/main/scala/scalismo/ui/view/ScalismoLookAndFeel.scala
+++ b/src/main/scala/scalismo/ui/view/ScalismoLookAndFeel.scala
@@ -18,7 +18,6 @@
 package scalismo.ui.view
 
 import javax.swing.{ ToolTipManager, UIDefaults, UIManager }
-
 import scalismo.ui.view.util.ScalableUI
 
 import scala.util.Try
@@ -33,7 +32,9 @@ object ScalismoLookAndFeel {
    */
   lazy val DefaultLookAndFeelClassName: String = {
     val nimbus = "javax.swing.plaf.nimbus.NimbusLookAndFeel"
+
     def system = UIManager.getSystemLookAndFeelClassName
+
     Stream(nimbus, system).find { laf => Try(Class.forName(laf)).isSuccess }.getOrElse(UIManager.getCrossPlatformLookAndFeelClassName)
   }
 

--- a/src/main/scala/scalismo/ui/view/StatusBar.scala
+++ b/src/main/scala/scalismo/ui/view/StatusBar.scala
@@ -75,8 +75,8 @@ class StatusBar extends BorderPanel {
 
     import BorderFactory._
 
-    val _3 = ScalableUI.scale(3)
-    val _2 = ScalableUI.scale(2)
+    private val _3 = ScalableUI.scale(3)
+    private val _2 = ScalableUI.scale(2)
     border = createCompoundBorder(createEmptyBorder(0, _3, _3, _3), createCompoundBorder(createEtchedBorder(), createEmptyBorder(_2, _2, _2, _2)))
 
     cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
@@ -119,7 +119,7 @@ class StatusBar extends BorderPanel {
 
   private val logPanel: BorderPanel = new BorderPanel {
     layout(new ScrollPane(log)) = BorderPanel.Position.Center
-    val toolBar = new ToolBar {
+    private val toolBar = new ToolBar {
       floatable = false
       rollover = false
       rollover = false

--- a/src/main/scala/scalismo/ui/view/StatusBar.scala
+++ b/src/main/scala/scalismo/ui/view/StatusBar.scala
@@ -20,8 +20,8 @@ package scalismo.ui.view
 import java.awt.event.{ MouseAdapter, MouseEvent }
 import java.awt.{ Color, Cursor, Font, Component => AComponent }
 import java.text.SimpleDateFormat
-import javax.swing._
 
+import javax.swing._
 import scalismo.ui.model.StatusMessage
 import scalismo.ui.model.StatusMessage._
 import scalismo.ui.resources.icons.BundledIcon

--- a/src/main/scala/scalismo/ui/view/StatusBar.scala
+++ b/src/main/scala/scalismo/ui/view/StatusBar.scala
@@ -71,7 +71,7 @@ class StatusBar extends BorderPanel {
     logPanel.visible = visible
   }
 
-  private val statusLabel = new Label("Welcome to the Scalismo Viewer!", BundledIcon.Smiley.standardSized(), Alignment.Leading) {
+  private val statusLabel: Label = new Label("Welcome to the Scalismo Viewer!", BundledIcon.Smiley.standardSized(), Alignment.Leading) {
 
     import BorderFactory._
 
@@ -88,7 +88,7 @@ class StatusBar extends BorderPanel {
     })
   }
 
-  private val logModel = new DefaultListModel[StatusMessage] {
+  private val logModel: DefaultListModel[StatusMessage] = new DefaultListModel[StatusMessage] {
     val MaxLength = 10000
 
     override def addElement(e: StatusMessage): Unit = {
@@ -117,7 +117,7 @@ class StatusBar extends BorderPanel {
 
   private val log = Component.wrap(jLog)
 
-  private val logPanel = new BorderPanel {
+  private val logPanel: BorderPanel = new BorderPanel {
     layout(new ScrollPane(log)) = BorderPanel.Position.Center
     val toolBar = new ToolBar {
       floatable = false

--- a/src/main/scala/scalismo/ui/view/ToolBar.scala
+++ b/src/main/scala/scalismo/ui/view/ToolBar.scala
@@ -35,9 +35,9 @@ class ToolBar extends Component with Orientable.Wrapper {
   }
 
   /**
-   * Convenience method to directly add an [[Action]] to a ToolBar.
+   * Convenience method to directly add a `scala.swing.Action` to a ToolBar.
    *
-   * This method will create a [[Button]] bound to the specified action,
+   * This method will create a `scala.swing.Button` bound to the specified action,
    * add it to the toolbar, and return that button.
    *
    * @param action the action to be added

--- a/src/main/scala/scalismo/ui/view/ToolBar.scala
+++ b/src/main/scala/scalismo/ui/view/ToolBar.scala
@@ -17,6 +17,8 @@
 
 package scalismo.ui.view
 
+import javax.swing.JButton
+
 import scala.swing.{ Action, Button, Component, Orientable }
 
 class ToolBar extends Component with Orientable.Wrapper {
@@ -46,7 +48,7 @@ class ToolBar extends Component with Orientable.Wrapper {
   def add(action: Action): Button = {
     val jb = peer.add(action.peer)
     new Button {
-      override lazy val peer = jb
+      override lazy val peer: JButton = jb
     }
   }
 

--- a/src/main/scala/scalismo/ui/view/ToolBar.scala
+++ b/src/main/scala/scalismo/ui/view/ToolBar.scala
@@ -22,13 +22,13 @@ import scala.swing.{ Action, Button, Component, Orientable }
 class ToolBar extends Component with Orientable.Wrapper {
   override lazy val peer = new javax.swing.JToolBar with SuperMixin
 
-  def add(c: Component) = {
+  def add(c: Component): Unit = {
     peer.add(c.peer)
     peer.repaint()
     peer.revalidate()
   }
 
-  def remove(c: Component) = {
+  def remove(c: Component): Unit = {
     peer.remove(c.peer)
     peer.repaint()
     peer.revalidate()
@@ -52,11 +52,11 @@ class ToolBar extends Component with Orientable.Wrapper {
 
   def floatable: Boolean = peer.isFloatable
 
-  def floatable_=(b: Boolean) = peer.setFloatable(b)
+  def floatable_=(b: Boolean): Unit = peer.setFloatable(b)
 
   def rollover: Boolean = peer.isRollover
 
-  def rollover_=(b: Boolean) = peer.setRollover(b)
+  def rollover_=(b: Boolean): Unit = peer.setRollover(b)
 
   // constructor
   floatable = false

--- a/src/main/scala/scalismo/ui/view/ViewportPanel.scala
+++ b/src/main/scala/scalismo/ui/view/ViewportPanel.scala
@@ -50,7 +50,7 @@ sealed abstract class ViewportPanel(val frame: ScalismoFrame) extends BorderPane
 
   val rendererPanel = new RendererPanel(this)
 
-  val toolBar = new ToolBar {
+  protected val toolBar: ToolBar = new ToolBar {
     floatable = false
     rollover = true
     orientation = Orientation.Horizontal
@@ -121,7 +121,7 @@ class ViewportPanel3D(frame: ScalismoFrame, override val name: String = "3D") ex
 class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPanel(frame) {
   override def name: String = axis.toString
 
-  lazy val positionSlider = new Slider {
+  private lazy val positionSlider = new Slider {
     peer.setOrientation(SwingConstants.VERTICAL)
   }
 
@@ -141,7 +141,7 @@ class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPane
     }
   })
 
-  lazy val sliderPanel = new BorderPanel {
+  private lazy val sliderPanel = new BorderPanel {
     layout(positionPlusButton) = BorderPanel.Position.North
     layout(positionSlider) = BorderPanel.Position.Center
     layout(positionMinusButton) = BorderPanel.Position.South

--- a/src/main/scala/scalismo/ui/view/ViewportPanel.scala
+++ b/src/main/scala/scalismo/ui/view/ViewportPanel.scala
@@ -197,10 +197,9 @@ class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPane
   reactions += {
     case SlicingPosition.event.PointChanged(_, _, current) => updateSliderValue(current)
     case SlicingPosition.event.BoundingBoxChanged(s) => updateSliderMinMax(s.boundingBox)
-    case SlicingPosition.event.PerspectiveChanged(s) => {
+    case SlicingPosition.event.PerspectiveChanged(s) =>
       updateSliderMinMax(s.boundingBox)
       updateSliderValue(s.point)
-    }
     case ValueChanged(s) if s eq positionSlider => sliderValueChanged()
   }
 }

--- a/src/main/scala/scalismo/ui/view/ViewportPanel.scala
+++ b/src/main/scala/scalismo/ui/view/ViewportPanel.scala
@@ -197,7 +197,10 @@ class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPane
   reactions += {
     case SlicingPosition.event.PointChanged(_, _, current) => updateSliderValue(current)
     case SlicingPosition.event.BoundingBoxChanged(s) => updateSliderMinMax(s.boundingBox)
-    case SlicingPosition.event.PerspectiveChanged(s) => { updateSliderMinMax(s.boundingBox); updateSliderValue(s.point) }
+    case SlicingPosition.event.PerspectiveChanged(s) => {
+      updateSliderMinMax(s.boundingBox);
+      updateSliderValue(s.point)
+    }
     case ValueChanged(s) if s eq positionSlider => sliderValueChanged()
   }
 }

--- a/src/main/scala/scalismo/ui/view/ViewportPanel.scala
+++ b/src/main/scala/scalismo/ui/view/ViewportPanel.scala
@@ -198,7 +198,7 @@ class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPane
     case SlicingPosition.event.PointChanged(_, _, current) => updateSliderValue(current)
     case SlicingPosition.event.BoundingBoxChanged(s) => updateSliderMinMax(s.boundingBox)
     case SlicingPosition.event.PerspectiveChanged(s) => {
-      updateSliderMinMax(s.boundingBox);
+      updateSliderMinMax(s.boundingBox)
       updateSliderValue(s.point)
     }
     case ValueChanged(s) if s eq positionSlider => sliderValueChanged()

--- a/src/main/scala/scalismo/ui/view/ViewportPanel.scala
+++ b/src/main/scala/scalismo/ui/view/ViewportPanel.scala
@@ -19,14 +19,12 @@ package scalismo.ui.view
 
 import javax.swing.border.TitledBorder
 import javax.swing.{ BorderFactory, SwingConstants }
-
 import scalismo.ui.control.SlicingPosition
 import scalismo.ui.event.ScalismoPublisher
 import scalismo.ui.model.{ Axis, BoundingBox, Scene }
 import scalismo.ui.rendering.{ RendererPanel, RendererState }
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.util.FileIoMetadata
-import scalismo.ui.view.PerspectivePanel.event.PerspectiveChanged
 import scalismo.ui.view.action.SaveAction
 import scalismo.ui.view.util.{ AxisColor, ScalableUI }
 

--- a/src/main/scala/scalismo/ui/view/ViewportPanel.scala
+++ b/src/main/scala/scalismo/ui/view/ViewportPanel.scala
@@ -119,7 +119,7 @@ class ViewportPanel3D(frame: ScalismoFrame, override val name: String = "3D") ex
 }
 
 class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPanel(frame) {
-  override def name = axis.toString
+  override def name: String = axis.toString
 
   lazy val positionSlider = new Slider {
     peer.setOrientation(SwingConstants.VERTICAL)

--- a/src/main/scala/scalismo/ui/view/action/AskForInputAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/AskForInputAction.scala
@@ -18,7 +18,6 @@
 package scalismo.ui.view.action
 
 import javax.swing.{ Icon, UIManager }
-
 import scalismo.ui.view.ScalismoFrame
 
 import scala.swing.Dialog.Message

--- a/src/main/scala/scalismo/ui/view/action/LoadAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/LoadAction.scala
@@ -48,13 +48,13 @@ class LoadAction(val load: File => Try[Unit], val metadata: FileIoMetadata, val 
 
   def parentComponent = frame.componentForDialogs
 
-  def apply() = {
+  def apply(): Unit = {
     if (chooser.showOpenDialog(parentComponent) == FileChooser.Result.Approve) {
       chooser.selectedFiles foreach tryLoad
     }
   }
 
-  def tryLoad(file: File) = {
+  def tryLoad(file: File): Unit = {
     val ok = load(file)
     ok match {
       case Success(_) => onSuccess(file)

--- a/src/main/scala/scalismo/ui/view/action/LoadAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/LoadAction.scala
@@ -18,8 +18,8 @@
 package scalismo.ui.view.action
 
 import java.io.File
-import javax.swing.filechooser.FileNameExtensionFilter
 
+import javax.swing.filechooser.FileNameExtensionFilter
 import scalismo.ui.model.StatusMessage
 import scalismo.ui.util.FileIoMetadata
 import scalismo.ui.view.ScalismoFrame

--- a/src/main/scala/scalismo/ui/view/action/LoadAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/LoadAction.scala
@@ -26,7 +26,7 @@ import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.dialog.ErrorDialog
 import scalismo.ui.view.util.EnhancedFileChooser
 
-import scala.swing.{ Action, FileChooser }
+import scala.swing.{ Action, Component, FileChooser }
 import scala.util.{ Failure, Success, Try }
 
 object LoadAction {
@@ -34,19 +34,19 @@ object LoadAction {
 }
 
 class LoadAction(val load: File => Try[Unit], val metadata: FileIoMetadata, val name: String = LoadAction.DefaultName, val multiSelect: Boolean = true)(implicit val frame: ScalismoFrame) extends Action(name) {
-  lazy val chooserTitle = {
+  private lazy val chooserTitle = {
     if (name != LoadAction.DefaultName) name
     else "Load " + metadata.description
   }
 
-  lazy val chooser = new EnhancedFileChooser() {
+  private lazy val chooser = new EnhancedFileChooser() {
     title = chooserTitle
     multiSelectionEnabled = multiSelect
     peer.setAcceptAllFileFilterUsed(false)
     fileFilter = new FileNameExtensionFilter(metadata.longDescription, metadata.fileExtensions: _*)
   }
 
-  def parentComponent = frame.componentForDialogs
+  def parentComponent: Component = frame.componentForDialogs
 
   def apply(): Unit = {
     if (chooser.showOpenDialog(parentComponent) == FileChooser.Result.Approve) {

--- a/src/main/scala/scalismo/ui/view/action/SaveAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/SaveAction.scala
@@ -18,8 +18,8 @@
 package scalismo.ui.view.action
 
 import java.io.File
-import javax.swing.filechooser.FileNameExtensionFilter
 
+import javax.swing.filechooser.FileNameExtensionFilter
 import scalismo.ui.model.StatusMessage
 import scalismo.ui.util.FileIoMetadata
 import scalismo.ui.view.ScalismoFrame
@@ -64,6 +64,7 @@ class SaveAction(val save: File => Try[Unit], val metadata: FileIoMetadata, val 
 
   def verifyThenSave(file: File) = {
     def candidateName = file.getName.toLowerCase
+
     var verified = true
     if (verifyFileExtension) {
       val matching = metadata.fileExtensions.filter {

--- a/src/main/scala/scalismo/ui/view/action/SaveAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/SaveAction.scala
@@ -26,7 +26,7 @@ import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.dialog.ErrorDialog
 import scalismo.ui.view.util.EnhancedFileChooser
 
-import scala.swing.{ Action, Dialog, FileChooser }
+import scala.swing.{ Action, Component, Dialog, FileChooser }
 import scala.util.{ Failure, Success, Try }
 
 object SaveAction {
@@ -36,19 +36,19 @@ object SaveAction {
 class SaveAction(val save: File => Try[Unit], val metadata: FileIoMetadata, val name: String = SaveAction.DefaultName)(implicit val frame: ScalismoFrame) extends Action(name) {
   lazy val confirmWhenExists = true
   lazy val verifyFileExtension = true
-  lazy val chooserTitle = {
+  private lazy val chooserTitle = {
     if (name != SaveAction.DefaultName) name
     else "Save " + metadata.description
   }
 
-  lazy val chooser = new EnhancedFileChooser() {
+  private lazy val chooser = new EnhancedFileChooser() {
     title = chooserTitle
     multiSelectionEnabled = false
     peer.setAcceptAllFileFilterUsed(false)
     fileFilter = new FileNameExtensionFilter(metadata.longDescription, metadata.fileExtensions: _*)
   }
 
-  def parentComponent = frame.componentForDialogs
+  def parentComponent: Component = frame.componentForDialogs
 
   def apply(): Unit = {
     if (chooser.showSaveDialog(parentComponent) == FileChooser.Result.Approve) {

--- a/src/main/scala/scalismo/ui/view/action/SaveAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/SaveAction.scala
@@ -50,7 +50,7 @@ class SaveAction(val save: File => Try[Unit], val metadata: FileIoMetadata, val 
 
   def parentComponent = frame.componentForDialogs
 
-  def apply() = {
+  def apply(): Unit = {
     if (chooser.showSaveDialog(parentComponent) == FileChooser.Result.Approve) {
       if (chooser.selectedFile.exists && confirmWhenExists) {
         val result = Dialog.showConfirmation(parentComponent, "The file " + chooser.selectedFile.getName + " already exists.\nDo you want to overwrite it?", "Overwrite existing file?", Dialog.Options.OkCancel)
@@ -62,7 +62,7 @@ class SaveAction(val save: File => Try[Unit], val metadata: FileIoMetadata, val 
     }
   }
 
-  def verifyThenSave(file: File) = {
+  def verifyThenSave(file: File): Unit = {
     def candidateName = file.getName.toLowerCase
 
     var verified = true
@@ -79,7 +79,7 @@ class SaveAction(val save: File => Try[Unit], val metadata: FileIoMetadata, val 
     if (verified) trySave(file)
   }
 
-  def trySave(file: File) = {
+  def trySave(file: File): Unit = {
     val ok = save(file)
     ok match {
       case Success(_) => onSuccess(file)

--- a/src/main/scala/scalismo/ui/view/action/popup/AddRigidTransformationAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/AddRigidTransformationAction.scala
@@ -17,7 +17,7 @@
 
 package scalismo.ui.view.action.popup
 
-import scalismo.ui.model.{ GenericTransformationsNode, GenericTransformationsNode$, PointTransformation, SceneNode }
+import scalismo.ui.model.{ GenericTransformationsNode, PointTransformation, SceneNode }
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.view.ScalismoFrame
 

--- a/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
@@ -25,8 +25,8 @@ import scalismo.ui.control.NodeVisibility
 import scalismo.ui.control.NodeVisibility.{ Invisible, PartlyVisible, Visible }
 import scalismo.ui.model.{ GroupNode, SceneNode }
 import scalismo.ui.resources.icons.BundledIcon
-import scalismo.ui.view.{ ScalismoFrame, ViewportPanel }
 import scalismo.ui.view.util.ScalableUI.implicits._
+import scalismo.ui.view.{ ScalismoFrame, ViewportPanel }
 
 import scala.swing._
 

--- a/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
@@ -42,7 +42,7 @@ object ChildVisibilityAction extends PopupAction.Factory {
 }
 
 class ChildVisibilityAction(nodes: List[GroupNode])(implicit frame: ScalismoFrame) extends PopupActionWithOwnMenu {
-  val control = frame.sceneControl.nodeVisibility
+  private val control = frame.sceneControl.nodeVisibility
 
   override def menuItem: JComponent = {
     val viewports = frame.perspective.viewports
@@ -87,10 +87,10 @@ class ChildVisibilityAction(nodes: List[GroupNode])(implicit frame: ScalismoFram
   }
 
   class ViewportVisibilityItem(viewports: List[ViewportPanel], name: String) extends Label(name) {
-    val tb = 2.scaled
-    val lr = 12.scaled
+    private val tb = 2.scaled
+    private val lr = 12.scaled
 
-    def currentState = control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), viewports)
+    private def currentState = control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), viewports)
 
     border = BorderFactory.createEmptyBorder(tb, lr, tb, lr)
     icon = iconFor(currentState)

--- a/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
@@ -47,7 +47,7 @@ class ChildVisibilityAction(nodes: List[GroupNode])(implicit frame: ScalismoFram
   override def menuItem: JComponent = {
     val viewports = frame.perspective.viewports
     if (viewports.length > 1) {
-      val menu = new Menu("Children visible in") {
+      val menu: Menu = new Menu("Children visible in") {
         def updateIcon(): Unit = {
           val state = control.getVisibilityState(nodes.flatMap(_.renderables.find(_ => true)), frame.perspective.viewports)
           icon = iconFor(state)

--- a/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/ChildVisibilityAction.scala
@@ -32,7 +32,7 @@ import scala.swing._
 
 object ChildVisibilityAction extends PopupAction.Factory {
   override def apply(nodes: List[SceneNode])(implicit frame: ScalismoFrame): List[PopupActionWithOwnMenu] = {
-    val affected = allMatch[GroupNode](nodes).filterNot(g => g.renderables.find(_ => true).size == 0)
+    val affected = allMatch[GroupNode](nodes).filter(g => g.renderables.nonEmpty)
     if (affected.isEmpty) {
       Nil
     } else {

--- a/src/main/scala/scalismo/ui/view/action/popup/LoadStatisticalShapeModelAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/LoadStatisticalShapeModelAction.scala
@@ -18,7 +18,6 @@
 package scalismo.ui.view.action.popup
 
 import java.io.File
-import javax.swing.text.TableView
 
 import scalismo.io.StatismoIO
 import scalismo.io.StatismoIO.{ CatalogEntry, StatismoModelType }
@@ -28,8 +27,7 @@ import scalismo.ui.util.{ FileIoMetadata, FileUtil }
 import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.action.LoadAction
 
-import scala.swing.BorderPanel.Position
-import scala.swing.{ Action, Alignment, BorderPanel, BoxPanel, Button, ComboBox, Dialog, FlowPanel, GridPanel, Label, Orientation, Swing, Table, TextArea, TextField }
+import scala.swing.{ Action, Alignment, BoxPanel, Button, ComboBox, Dialog, FlowPanel, GridPanel, Label, Orientation }
 import scala.util.{ Failure, Success, Try }
 
 object LoadStatisticalShapeModelAction extends PopupAction.Factory {
@@ -74,11 +72,6 @@ class LoadStatisticalShapeModelAction(group: GroupNode)(implicit frame: Scalismo
         } else if (entries.length == 1) {
           Success(entries.head.modelPath)
         } else {
-          val title = "Select shape model to load"
-          val description = "The file contains more that one shape model. Please select the one you wish to load."
-
-          var items = List("Item 1", "Item 2", "Item 3", "Item 4")
-
           val dialog = new ShapeModelSelectionDialog(entries)
           dialog.open()
 

--- a/src/main/scala/scalismo/ui/view/action/popup/LoadStatisticalShapeModelAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/LoadStatisticalShapeModelAction.scala
@@ -113,7 +113,7 @@ class LoadStatisticalShapeModelAction(group: GroupNode)(implicit frame: Scalismo
 
     // the path entry will always be found, as the user can only select entries from the
     // same list. Hence .get is justified here.
-    def path = entries.find(_.name == combo.selection.item).get.modelPath
+    def path: String = entries.find(_.name == combo.selection.item).get.modelPath
 
   }
 

--- a/src/main/scala/scalismo/ui/view/action/popup/PopupAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/PopupAction.scala
@@ -18,7 +18,6 @@
 package scalismo.ui.view.action.popup
 
 import javax.swing.{ Icon, JComponent }
-
 import scalismo.ui.model.SceneNode
 import scalismo.ui.util.NodeListFilters
 import scalismo.ui.view.ScalismoFrame

--- a/src/main/scala/scalismo/ui/view/action/popup/PopupAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/PopupAction.scala
@@ -54,11 +54,11 @@ object PopupAction {
 
   def factories: List[Factory] = _factories
 
-  def addFactory(factory: Factory) = {
+  def addFactory(factory: Factory): Unit = {
     _factories = factory :: _factories
   }
 
-  def removeFactory(factory: Factory) = {
+  def removeFactory(factory: Factory): Unit = {
     _factories = _factories.filter(_ != factory)
   }
 

--- a/src/main/scala/scalismo/ui/view/action/popup/SaveLandmarksAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/SaveLandmarksAction.scala
@@ -55,7 +55,7 @@ object SaveLandmarksAction extends PopupAction.Factory {
 
 // the companion object took care of the safety checks, like making sure the list is not empty etc.
 class SaveLandmarksAction private (nodes: List[LandmarkNode], transformedFlag: Boolean = true)(implicit val frame: ScalismoFrame) extends PopupAction(s"Save${if (transformedFlag) " transformed" else " original"} ${FileIoMetadata.Landmarks.description} ...", BundledIcon.Save) {
-  val landmarks = nodes.head.parent
+  private val landmarks = nodes.head.parent
 
   def doSave(file: File): Try[Unit] = {
     landmarks.saveNodes(nodes, file, transformedFlag)

--- a/src/main/scala/scalismo/ui/view/action/popup/SaveLandmarksAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/SaveLandmarksAction.scala
@@ -36,7 +36,7 @@ object SaveLandmarksAction extends PopupAction.Factory {
       if (landmarksNodeOpt.isEmpty) {
         Nil
       } else {
-        if (landmarksNodeOpt.get.children.length > 0) {
+        if (landmarksNodeOpt.get.children.nonEmpty) {
           List(new SaveLandmarksAction(landmarksNodeOpt.get.children), new SaveLandmarksAction(landmarksNodeOpt.get.children, false))
         } else Nil
       }

--- a/src/main/scala/scalismo/ui/view/action/popup/SaveLandmarksAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/SaveLandmarksAction.scala
@@ -19,7 +19,7 @@ package scalismo.ui.view.action.popup
 
 import java.io.File
 
-import scalismo.ui.model.{ GroupNode, LandmarksNode, LandmarkNode, SceneNode }
+import scalismo.ui.model.{ LandmarkNode, LandmarksNode, SceneNode }
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.util.FileIoMetadata
 import scalismo.ui.view.ScalismoFrame

--- a/src/main/scala/scalismo/ui/view/action/popup/VisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/VisibilityAction.scala
@@ -87,10 +87,10 @@ class VisibilityAction(nodes: List[RenderableSceneNode])(implicit frame: Scalism
   }
 
   class ViewportVisibilityItem(viewports: List[ViewportPanel], name: String) extends Label(name) {
-    val tb = 2.scaled
-    val lr = 12.scaled
+    private val tb = 2.scaled
+    private val lr = 12.scaled
 
-    def currentState = control.getVisibilityState(nodes, viewports)
+    def currentState: NodeVisibility.State = control.getVisibilityState(nodes, viewports)
 
     border = BorderFactory.createEmptyBorder(tb, lr, tb, lr)
     icon = iconFor(currentState)

--- a/src/main/scala/scalismo/ui/view/action/popup/VisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/VisibilityAction.scala
@@ -19,15 +19,15 @@ package scalismo.ui.view.action.popup
 
 import java.awt.Color
 import java.awt.event.{ MouseAdapter, MouseEvent }
-import javax.swing.{ BorderFactory, Icon, JComponent }
 
+import javax.swing.{ BorderFactory, Icon, JComponent }
 import scalismo.ui.control.NodeVisibility
 import scalismo.ui.control.NodeVisibility.{ Invisible, PartlyVisible, Visible }
 import scalismo.ui.model.SceneNode
 import scalismo.ui.model.capabilities.RenderableSceneNode
 import scalismo.ui.resources.icons.BundledIcon
-import scalismo.ui.view.{ ScalismoFrame, ViewportPanel }
 import scalismo.ui.view.util.ScalableUI.implicits._
+import scalismo.ui.view.{ ScalismoFrame, ViewportPanel }
 
 import scala.swing._
 

--- a/src/main/scala/scalismo/ui/view/action/popup/VisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/VisibilityAction.scala
@@ -48,7 +48,7 @@ class VisibilityAction(nodes: List[RenderableSceneNode])(implicit frame: Scalism
   override def menuItem: JComponent = {
     val viewports = frame.perspective.viewports
     if (viewports.length > 1) {
-      val menu = new Menu("Visible in") {
+      val menu: Menu = new Menu("Visible in") {
         def updateIcon(): Unit = {
           icon = iconFor(control.getVisibilityState(nodes, frame.perspective.viewports))
         }

--- a/src/main/scala/scalismo/ui/view/action/popup/VisibilityAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/VisibilityAction.scala
@@ -43,7 +43,7 @@ object VisibilityAction extends PopupAction.Factory {
 }
 
 class VisibilityAction(nodes: List[RenderableSceneNode])(implicit frame: ScalismoFrame) extends PopupActionWithOwnMenu {
-  val control = frame.sceneControl.nodeVisibility
+  private val control = frame.sceneControl.nodeVisibility
 
   override def menuItem: JComponent = {
     val viewports = frame.perspective.viewports

--- a/src/main/scala/scalismo/ui/view/dialog/AboutDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/AboutDialog.scala
@@ -49,8 +49,8 @@ object AboutDialog {
 
     import scala.reflect.runtime.universe
 
-    lazy val runtimeMirror = universe.runtimeMirror(getClass.getClassLoader)
-    lazy val objectName = "scalismo.ui.BuildInfo$"
+    private lazy val runtimeMirror = universe.runtimeMirror(getClass.getClassLoader)
+    private lazy val objectName = "scalismo.ui.BuildInfo$"
 
     def proxy(fieldName: String): String = Try {
       val moduleSymbol = runtimeMirror.moduleSymbol(
@@ -90,17 +90,17 @@ object AboutDialog {
     * the values defined here, not a literal value)
      */
 
-    def s_3 = 3.scaled
+    def s_3: Int = 3.scaled
 
-    def s_5 = 5.scaled
+    def s_5: Int = 5.scaled
 
-    def s_10 = 10.scaled
+    def s_10: Int = 10.scaled
 
-    def s_15 = 15.scaled
+    def s_15: Int = 15.scaled
 
-    def s_20 = 20.scaled
+    def s_20: Int = 20.scaled
 
-    def s_128 = 128.scaled
+    def s_128: Int = 128.scaled
   }
 
   class BoldLabel(text: String, icon: Icon = EmptyIcon, alignment: Alignment.Value = Alignment.Center) extends Label(text, icon, alignment) {
@@ -108,15 +108,15 @@ object AboutDialog {
   }
 
   class LogoPanel extends BorderPanel {
-    val logo = BundledIcon.Logo
-    val dim = s_128
-    val scaledIcon = ScalableUI.resizeIcon(logo, dim, dim)
+    private val logo = BundledIcon.Logo
+    private val dim = s_128
+    private val scaledIcon = ScalableUI.resizeIcon(logo, dim, dim)
 
-    val image = new LinkLabel("", new URI("https://github.com/unibas-gravis/scalismo"), scaledIcon, Alignment.Left, preventLinkStyle = true, preventTooltip = true) {
+    private val image = new LinkLabel("", new URI("https://github.com/unibas-gravis/scalismo"), scaledIcon, Alignment.Left, preventLinkStyle = true, preventTooltip = true) {
       peer.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR))
     }
 
-    val h = s_15
+    private val h = s_15
     image.border = BorderFactory.createEmptyBorder(h * 2, h, h * 2, h)
 
     layout(image) = BorderPanel.Position.North
@@ -127,7 +127,7 @@ object AboutDialog {
     private var y = 0
     val columns = 2
 
-    def constraints(text: String) = new Constraints {
+    private def constraints(text: String): Constraints = new Constraints {
       this.gridx = x
       this.gridy = y
       this.anchor = Anchor.NorthWest
@@ -157,20 +157,20 @@ object AboutDialog {
   class ThirdPartyPanel(frame: ScalismoFrame) extends BorderPanel {
     val description = "The scalismo library, and the user interface, use a number of third-party open source resources. These dependencies are listed below."
 
-    val descriptionBorder = BorderFactory.createEmptyBorder(s_10, 0, s_10, 0)
-    val thanksBorder = BorderFactory.createEmptyBorder(s_10, 0, 0, 0)
-    val listBorder = BorderFactory.createEmptyBorder(s_3, s_10, s_3, s_10)
-    val scrollBorder = BorderFactory.createEmptyBorder(0, 0, 0, s_10)
+    private val descriptionBorder = BorderFactory.createEmptyBorder(s_10, 0, s_10, 0)
+    private val thanksBorder = BorderFactory.createEmptyBorder(s_10, 0, 0, 0)
+    private val listBorder = BorderFactory.createEmptyBorder(s_3, s_10, s_3, s_10)
+    private val scrollBorder = BorderFactory.createEmptyBorder(0, 0, 0, s_10)
 
-    val north = new MultiLineLabel(description) {
+    private val north = new MultiLineLabel(description) {
       border = descriptionBorder
     }
 
     val center: BorderPanel = new BorderPanel {
-      val list = new ThirdPartyListPanel(frame) {
+      private val list = new ThirdPartyListPanel(frame) {
         border = listBorder
       }
-      val scroll = new ScrollPane(list) {
+      private val scroll = new ScrollPane(list) {
         horizontalScrollBarPolicy = ScrollPane.BarPolicy.AsNeeded
         verticalScrollBarPolicy = ScrollPane.BarPolicy.AsNeeded
       }
@@ -190,10 +190,10 @@ object AboutDialog {
     private var x = 0
     private var y = 0
     val columns = List("Name", "Author(s)", "License")
-    val lastColumnIndex = columns.length - 1
-    val lastRowIndex = ThirdPartyResource.All.length + 1 // accounts for header and footer
+    private val lastColumnIndex = columns.length - 1
+    private val lastRowIndex = ThirdPartyResource.All.length + 1 // accounts for header and footer
 
-    def constraints() = new Constraints {
+    private def constraints(): Constraints = new Constraints {
       this.gridx = x
       this.gridy = y
       this.anchor = Anchor.NorthWest
@@ -324,7 +324,7 @@ class AboutDialog(implicit frame: ScalismoFrame) extends Dialog(frame) {
   modal = true
   title = "About Scalismo UI"
 
-  def withLogo(component: Component) = new BorderPanel {
+  private def withLogo(component: Component): BorderPanel = new BorderPanel {
     layout(component) = BorderPanel.Position.Center
     layout(new LogoPanel) = BorderPanel.Position.West
   }
@@ -340,14 +340,14 @@ class AboutDialog(implicit frame: ScalismoFrame) extends Dialog(frame) {
       "Build Time" -> BuildInfo.buildTime
     )
 
-    val kvPanel: BorderPanel = new BorderPanel {
-      val west = new BorderPanel {
+    private val kvPanel: BorderPanel = new BorderPanel {
+      val west: BorderPanel = new BorderPanel {
         layout(new KeyValuePanel(keyValue)) = BorderPanel.Position.Center
       }
 
       layout(west) = BorderPanel.Position.West
       layout(new LinkLabel("Copyright (c) Graphics and Vision Research Group, University of Basel", new URI("http://gravis.cs.unibas.ch/"), alignment = Alignment.Left, preventLinkStyle = true, preventTooltip = true) {
-        val b = s_10
+        private val b = s_10
         border = BorderFactory.createEmptyBorder(b, b, b, b)
       }) = BorderPanel.Position.North
     }
@@ -364,7 +364,7 @@ class AboutDialog(implicit frame: ScalismoFrame) extends Dialog(frame) {
       })
       layout(new BorderPanel {
         layout(ok) = BorderPanel.Position.Center
-        val b = s_5
+        private val b = s_5
         border = BorderFactory.createEmptyBorder(b, b, b, b)
       }) = BorderPanel.Position.East
     }

--- a/src/main/scala/scalismo/ui/view/dialog/AboutDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/AboutDialog.scala
@@ -166,7 +166,7 @@ object AboutDialog {
       border = descriptionBorder
     }
 
-    val center = new BorderPanel {
+    val center: BorderPanel = new BorderPanel {
       val list = new ThirdPartyListPanel(frame) {
         border = listBorder
       }
@@ -329,7 +329,7 @@ class AboutDialog(implicit frame: ScalismoFrame) extends Dialog(frame) {
     layout(new LogoPanel) = BorderPanel.Position.West
   }
 
-  val main = new BorderPanel {
+  val main: BorderPanel = new BorderPanel {
 
     val keyValue = List(
       "Developers" -> "<html>Ghazi Bouabene<br/>Thomas Gerig<br/>Christoph Langguth<br/>Marcel Lüthi</html>",
@@ -340,7 +340,7 @@ class AboutDialog(implicit frame: ScalismoFrame) extends Dialog(frame) {
       "Build Time" -> BuildInfo.buildTime
     )
 
-    val kvPanel = new BorderPanel {
+    val kvPanel: BorderPanel = new BorderPanel {
       val west = new BorderPanel {
         layout(new KeyValuePanel(keyValue)) = BorderPanel.Position.Center
       }
@@ -358,7 +358,7 @@ class AboutDialog(implicit frame: ScalismoFrame) extends Dialog(frame) {
     tabsPane.pages += new Page("Scalismo UI", withLogo(kvPanel), null)
     tabsPane.pages += new Page("Third Party", withLogo(new ThirdPartyPanel(frame)), null)
 
-    val bottomPanel = new BorderPanel {
+    val bottomPanel: BorderPanel = new BorderPanel {
       val ok = new Button(new Action("OK") {
         override def apply(): Unit = AboutDialog.this.dispose()
       })

--- a/src/main/scala/scalismo/ui/view/dialog/AboutDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/AboutDialog.scala
@@ -54,7 +54,8 @@ object AboutDialog {
 
     def proxy(fieldName: String): String = Try {
       val moduleSymbol = runtimeMirror.moduleSymbol(
-        Class.forName(objectName))
+        Class.forName(objectName)
+      )
 
       val targetMethod = moduleSymbol.typeSignature
         .members

--- a/src/main/scala/scalismo/ui/view/dialog/AboutDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/AboutDialog.scala
@@ -20,8 +20,8 @@ package scalismo.ui.view.dialog
 import java.awt.event.{ MouseAdapter, MouseEvent }
 import java.awt.{ Color, Cursor, Font }
 import java.net.URI
-import javax.swing._
 
+import javax.swing._
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.resources.thirdparty.ThirdPartyResource
 import scalismo.ui.view.ScalismoFrame

--- a/src/main/scala/scalismo/ui/view/dialog/DisplayScalingDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/DisplayScalingDialog.scala
@@ -53,11 +53,11 @@ class DisplayScalingDialog(implicit val frame: ScalismoFrame) extends Dialog(fra
 
   val initialScale = Math.round(ScalableUI.scaleFactor * 100)
 
-  val example = new Label("This is an example of how the User Interface would look at the chosen setting.") {
+  val example: Label = new Label("This is an example of how the User Interface would look at the chosen setting.") {
     val b = Constants.DefaultFontSize
     border = BorderFactory.createEmptyBorder(b, b, b, b)
   }
-  val main = new BorderPanel {
+  val main: BorderPanel = new BorderPanel {
     val b = 5.scaled
     border = BorderFactory.createEmptyBorder(b, b, b, b)
   }

--- a/src/main/scala/scalismo/ui/view/dialog/DisplayScalingDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/DisplayScalingDialog.scala
@@ -51,14 +51,14 @@ class DisplayScalingDialog(implicit val frame: ScalismoFrame) extends Dialog(fra
     }
   })
 
-  val initialScale = Math.round(ScalableUI.scaleFactor * 100)
+  private val initialScale = Math.round(ScalableUI.scaleFactor * 100)
 
   val example: Label = new Label("This is an example of how the User Interface would look at the chosen setting.") {
-    val b = Constants.DefaultFontSize
+    private val b = Constants.DefaultFontSize
     border = BorderFactory.createEmptyBorder(b, b, b, b)
   }
   val main: BorderPanel = new BorderPanel {
-    val b = 5.scaled
+    private val b = 5.scaled
     border = BorderFactory.createEmptyBorder(b, b, b, b)
   }
 

--- a/src/main/scala/scalismo/ui/view/dialog/DisplayScalingDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/DisplayScalingDialog.scala
@@ -57,12 +57,13 @@ class DisplayScalingDialog(implicit val frame: ScalismoFrame) extends Dialog(fra
     private val b = Constants.DefaultFontSize
     border = BorderFactory.createEmptyBorder(b, b, b, b)
   }
+
   val main: BorderPanel = new BorderPanel {
     private val b = 5.scaled
     border = BorderFactory.createEmptyBorder(b, b, b, b)
   }
 
-  val scaleSlider = new FancySlider {
+  private class ScaleSlider extends FancySlider {
     min = 25
     max = 400
     value = initialScale
@@ -71,6 +72,8 @@ class DisplayScalingDialog(implicit val frame: ScalismoFrame) extends Dialog(fra
 
     def sliderLabels: List[Component] = List(minLabel, maxLabel, valueLabel)
   }
+
+  private val scaleSlider = new ScaleSlider()
 
   // when the user is done sliding, re-pack the window
 

--- a/src/main/scala/scalismo/ui/view/dialog/DisplayScalingDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/DisplayScalingDialog.scala
@@ -19,8 +19,8 @@ package scalismo.ui.view.dialog
 
 import java.awt.Font
 import java.awt.event.{ KeyAdapter, KeyEvent, MouseAdapter, MouseEvent }
-import javax.swing.BorderFactory
 
+import javax.swing.BorderFactory
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.util.ScalableUI.implicits.scalableInt

--- a/src/main/scala/scalismo/ui/view/dialog/ErrorDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/ErrorDialog.scala
@@ -44,26 +44,26 @@ class ErrorDialog(exception: Throwable, title: String, additionalMessage: String
 
   val main = new BorderPanel
 
-  val icon = {
+  private val icon = {
     val fallback = UIManager.getIcon("OptionPane.errorIcon")
     iconOverride.map(_.resize(fallback.getIconWidth, fallback.getIconHeight)).getOrElse(fallback)
   }
 
-  val iconLabel = new Label("", icon, Alignment.Center)
+  private val iconLabel = new Label("", icon, Alignment.Center)
 
-  val placeHolderMessageLabel = {
+  private val placeHolderMessageLabel = {
     val textOption = Option(exception.getMessage)
     val text = textOption.getOrElse(exception.getClass.getName)
     new Label(text, icon, Alignment.Right)
   }
 
-  val placeHolderAdditionalLabelOption: Option[Label] = additionalMessage match {
+  private val placeHolderAdditionalLabelOption: Option[Label] = additionalMessage match {
     case null => None
     case s if s.trim.length == 0 => None
     case text => Some(new Label(text, icon, Alignment.Right))
   }
 
-  val messageLabel = {
+  private val messageLabel = {
     val fullText = placeHolderAdditionalLabelOption match {
       case Some(label) => s"${label.text}\n\n${placeHolderMessageLabel.text}"
       case None => ""
@@ -71,12 +71,12 @@ class ErrorDialog(exception: Throwable, title: String, additionalMessage: String
     new MultiLineLabel(fullText)
   }
 
-  val messagePanel = new BorderPanel {
+  private val messagePanel = new BorderPanel {
     layout(iconLabel) = BorderPanel.Position.West
     layout(messageLabel) = BorderPanel.Position.Center
   }
 
-  val stackTrace = {
+  private val stackTrace = {
     val trace = new StringWriter()
     exception.printStackTrace(new PrintWriter(trace))
 
@@ -88,7 +88,7 @@ class ErrorDialog(exception: Throwable, title: String, additionalMessage: String
     new ScrollPane(area)
   }
 
-  val placeholder = Component.wrap(new JComponent {
+  private val placeholder = Component.wrap(new JComponent {
     override def getPreferredSize: Dimension = {
       val size = new Dimension
       size.height = 0
@@ -120,7 +120,7 @@ class ErrorDialog(exception: Throwable, title: String, additionalMessage: String
     override def apply(): Unit = dispose()
   })
 
-  val buttons = new BorderPanel {
+  private val buttons = new BorderPanel {
     layout(okButton) = BorderPanel.Position.East
     layout(detailsButton) = BorderPanel.Position.West
   }

--- a/src/main/scala/scalismo/ui/view/dialog/ErrorDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/ErrorDialog.scala
@@ -18,8 +18,8 @@
 package scalismo.ui.view.dialog
 
 import java.io.{ PrintWriter, StringWriter }
-import javax.swing.{ BorderFactory, JComponent, UIManager }
 
+import javax.swing.{ BorderFactory, JComponent, UIManager }
 import scalismo.ui.resources.icons.ScalableIcon
 import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.util.{ MultiLineLabel, ScalableUI }

--- a/src/main/scala/scalismo/ui/view/perspective/Perspective.scala
+++ b/src/main/scala/scalismo/ui/view/perspective/Perspective.scala
@@ -29,7 +29,7 @@ trait Perspective extends CardPanel.ComponentWithUniqueId {
 
   final override val uniqueId = factory.perspectiveName
 
-  override def toString = factory.perspectiveName
+  override def toString: String = factory.perspectiveName
 }
 
 object Perspective {

--- a/src/main/scala/scalismo/ui/view/perspective/PerspectiveFactory.scala
+++ b/src/main/scala/scalismo/ui/view/perspective/PerspectiveFactory.scala
@@ -51,7 +51,7 @@ object PerspectiveFactory {
     _factories = factories.filterNot(_ == factory)
   }
 
-  var defaultPerspective: PerspectiveFactory = {
+  val defaultPerspective: PerspectiveFactory = {
     val userPreferred = GlobalSettings.get[String](GlobalSettings.Keys.PerspectiveName).flatMap { name => factories.find(_.perspectiveName == name) }
     userPreferred.getOrElse(factories.head)
   }

--- a/src/main/scala/scalismo/ui/view/perspective/PerspectiveFactory.scala
+++ b/src/main/scala/scalismo/ui/view/perspective/PerspectiveFactory.scala
@@ -43,11 +43,11 @@ object PerspectiveFactory {
 
   def factories: List[PerspectiveFactory] = _factories
 
-  def addFactory(factory: PerspectiveFactory) = {
+  def addFactory(factory: PerspectiveFactory): Unit = {
     _factories ++= List(factory)
   }
 
-  def removeFactory(factory: PerspectiveFactory) = {
+  def removeFactory(factory: PerspectiveFactory): Unit = {
     _factories = factories.filterNot(_ == factory)
   }
 

--- a/src/main/scala/scalismo/ui/view/properties/GaussianProcessCoefficientsPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/GaussianProcessCoefficientsPanel.scala
@@ -56,7 +56,7 @@ class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extend
 
   private case class Entry(index: Int) {
     val label = new Label(index.toString)
-    val slider = new Slider {
+    val slider: Slider = new Slider {
       override lazy val peer = new JSlider with SuperMixin {
         // this tries to jump directly to the value the user clicked.
         addMouseListener(new MouseAdapter() {

--- a/src/main/scala/scalismo/ui/view/properties/GaussianProcessCoefficientsPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/GaussianProcessCoefficientsPanel.scala
@@ -60,7 +60,7 @@ class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extend
       override lazy val peer = new JSlider with SuperMixin {
         // this tries to jump directly to the value the user clicked.
         addMouseListener(new MouseAdapter() {
-          override def mousePressed(e: MouseEvent) = {
+          override def mousePressed(e: MouseEvent): Unit = {
             val p = e.getPoint
             val percent = p.x / getWidth.toDouble
             val range = getMaximum - getMinimum
@@ -83,7 +83,7 @@ class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extend
     val entries: mutable.Buffer[Entry] = new mutable.ArrayBuffer
 
     // need to redefine because add() is protected in superclass
-    def add(comp: Component, position: (Int, Int)) = {
+    def add(comp: Component, position: (Int, Int)): Unit = {
       val const = pair2Constraints(position)
       const.ipadx = 10.scaled
       if (position._1 == 0) {
@@ -135,13 +135,13 @@ class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extend
 
   def labelFormat(value: Double) = f"$value%1.1f"
 
-  def resetValues() = {
+  def resetValues(): Unit = {
     node.foreach { n =>
       n.transformation = n.transformation.copy(coefficients = DenseVector.zeros[Double](n.transformation.gp.rank))
     }
   }
 
-  private def setCoefficient(index: Int, value: Double) = {
+  private def setCoefficient(index: Int, value: Double): Unit = {
     node.foreach { n =>
       val coeffs = n.transformation.coefficients.toArray
       if (coeffs(index) != value) {
@@ -151,7 +151,7 @@ class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extend
     }
   }
 
-  def randomizeValues() = {
+  def randomizeValues(): Unit = {
     node.foreach { n =>
       val coeffs = n.transformation.coefficients.toArray
       coeffs.indices.foreach { index =>
@@ -164,7 +164,7 @@ class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extend
 
   private val table = new Table
 
-  def updateDisplayedCoefficients() = {
+  def updateDisplayedCoefficients(): Unit = {
     node.foreach { n =>
       val coeffs = n.transformation.coefficients.toArray
       coeffs.indices foreach { i =>
@@ -195,7 +195,7 @@ class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extend
       updateDisplayedCoefficients()
   }
 
-  def cleanup() = {
+  def cleanup(): Unit = {
     node.foreach { n =>
       deafTo(n)
       node = None

--- a/src/main/scala/scalismo/ui/view/properties/GaussianProcessCoefficientsPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/GaussianProcessCoefficientsPanel.scala
@@ -18,10 +18,10 @@
 package scalismo.ui.view.properties
 
 import java.awt.event.{ MouseAdapter, MouseEvent }
-import javax.swing.JSlider
 
 import breeze.linalg.DenseVector
 import breeze.stats.distributions.Gaussian
+import javax.swing.JSlider
 import scalismo.ui.model.{ LowRankGpPointTransformation, PointTransformation, SceneNode, TransformationNode }
 import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.util.ScalableUI.implicits.scalableInt

--- a/src/main/scala/scalismo/ui/view/properties/GaussianProcessCoefficientsPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/GaussianProcessCoefficientsPanel.scala
@@ -46,7 +46,7 @@ class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extend
   val random = new Button("Random")
   listenTo(reset, random)
 
-  val buttons = {
+  private val buttons = {
     val panel = new GridPanel(1, 2)
     panel.contents ++= Seq(reset, random)
     panel
@@ -57,7 +57,7 @@ class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extend
   private case class Entry(index: Int) {
     val label = new Label(index.toString)
     val slider: Slider = new Slider {
-      override lazy val peer = new JSlider with SuperMixin {
+      override lazy val peer: JSlider with SuperMixin = new JSlider with SuperMixin {
         // this tries to jump directly to the value the user clicked.
         addMouseListener(new MouseAdapter() {
           override def mousePressed(e: MouseEvent): Unit = {

--- a/src/main/scala/scalismo/ui/view/properties/GaussianProcessCoefficientsPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/GaussianProcessCoefficientsPanel.scala
@@ -34,8 +34,9 @@ import scala.swing.event.{ ButtonClicked, ValueChanged }
 object GaussianProcessCoefficientsPanel extends PropertyPanel.Factory {
   override def create(frame: ScalismoFrame): PropertyPanel = new GaussianProcessCoefficientsPanel(frame)
 
-  var MaxAbsoluteCoefficientValue: Float = 3.0f
-  var CoefficientValueStep: Float = 0.1f
+  val MaxAbsoluteCoefficientValue: Float = 3.0f
+
+  val CoefficientValueStep: Float = 0.1f
 }
 
 class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extends BorderPanel with PropertyPanel {
@@ -79,7 +80,7 @@ class GaussianProcessCoefficientsPanel(override val frame: ScalismoFrame) extend
   }
 
   private class Table extends GridBagPanel {
-    var entries: mutable.Buffer[Entry] = new mutable.ArrayBuffer
+    val entries: mutable.Buffer[Entry] = new mutable.ArrayBuffer
 
     // need to redefine because add() is protected in superclass
     def add(comp: Component, position: (Int, Int)) = {

--- a/src/main/scala/scalismo/ui/view/properties/LineWidthPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/LineWidthPropertyPanel.scala
@@ -44,7 +44,7 @@ class LineWidthPropertyPanel(override val frame: ScalismoFrame) extends BorderPa
   }
 
   layout(new BorderPanel {
-    val sliderPanel = new BorderPanel {
+    val sliderPanel: BorderPanel = new BorderPanel {
       border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
       layout(slider) = BorderPanel.Position.Center
     }

--- a/src/main/scala/scalismo/ui/view/properties/LineWidthPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/LineWidthPropertyPanel.scala
@@ -18,7 +18,6 @@
 package scalismo.ui.view.properties
 
 import javax.swing.border.TitledBorder
-
 import scalismo.ui.model.SceneNode
 import scalismo.ui.model.properties.{ HasLineWidth, LineWidthProperty, NodeProperty }
 import scalismo.ui.view.ScalismoFrame

--- a/src/main/scala/scalismo/ui/view/properties/LineWidthPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/LineWidthPropertyPanel.scala
@@ -85,7 +85,7 @@ class LineWidthPropertyPanel(override val frame: ScalismoFrame) extends BorderPa
 
   reactions += {
     case NodeProperty.event.PropertyChanged(_) => updateUi()
-    case ValueChanged(c) => targets.foreach(_.lineWidth.value = slider.value)
+    case ValueChanged(_) => targets.foreach(_.lineWidth.value = slider.value)
   }
 
 }

--- a/src/main/scala/scalismo/ui/view/properties/LineWidthPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/LineWidthPropertyPanel.scala
@@ -53,15 +53,15 @@ class LineWidthPropertyPanel(override val frame: ScalismoFrame) extends BorderPa
 
   listenToOwnEvents()
 
-  def listenToOwnEvents() = {
+  def listenToOwnEvents(): Unit = {
     listenTo(slider)
   }
 
-  def deafToOwnEvents() = {
+  def deafToOwnEvents(): Unit = {
     deafTo(slider)
   }
 
-  def updateUi() = {
+  def updateUi(): Unit = {
     deafToOwnEvents()
     targets.headOption.foreach(t => slider.value = t.lineWidth.value)
     listenToOwnEvents()

--- a/src/main/scala/scalismo/ui/view/properties/OpacityPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/OpacityPropertyPanel.scala
@@ -47,7 +47,7 @@ class OpacityPropertyPanel(override val frame: ScalismoFrame) extends BorderPane
   }
 
   layout(new BorderPanel {
-    val sliderPanel = new BorderPanel {
+    private val sliderPanel = new BorderPanel {
       border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
       layout(slider) = BorderPanel.Position.Center
     }

--- a/src/main/scala/scalismo/ui/view/properties/OpacityPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/OpacityPropertyPanel.scala
@@ -56,15 +56,15 @@ class OpacityPropertyPanel(override val frame: ScalismoFrame) extends BorderPane
 
   listenToOwnEvents()
 
-  def listenToOwnEvents() = {
+  def listenToOwnEvents(): Unit = {
     listenTo(slider)
   }
 
-  def deafToOwnEvents() = {
+  def deafToOwnEvents(): Unit = {
     deafTo(slider)
   }
 
-  def updateUi() = {
+  def updateUi(): Unit = {
     deafToOwnEvents()
     targets.headOption.foreach(t => slider.value = (t.opacity.value * 100.0f).toInt)
     listenToOwnEvents()

--- a/src/main/scala/scalismo/ui/view/properties/OpacityPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/OpacityPropertyPanel.scala
@@ -88,7 +88,7 @@ class OpacityPropertyPanel(override val frame: ScalismoFrame) extends BorderPane
 
   reactions += {
     case NodeProperty.event.PropertyChanged(_) => updateUi()
-    case ValueChanged(c) => targets.foreach(_.opacity.value = slider.value.toFloat / 100.0f)
+    case ValueChanged(_) => targets.foreach(_.opacity.value = slider.value.toFloat / 100.0f)
   }
 
 }

--- a/src/main/scala/scalismo/ui/view/properties/OpacityPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/OpacityPropertyPanel.scala
@@ -18,7 +18,6 @@
 package scalismo.ui.view.properties
 
 import javax.swing.border.TitledBorder
-
 import scalismo.ui.model.SceneNode
 import scalismo.ui.model.properties.{ HasOpacity, NodeProperty }
 import scalismo.ui.view.ScalismoFrame

--- a/src/main/scala/scalismo/ui/view/properties/PropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/PropertyPanel.scala
@@ -24,7 +24,7 @@ import scalismo.ui.view.util.CardPanel
 
 /**
  * A PropertyPanel is a UI component to show or manipulate aspects of
- * [[SceneNode]]s.
+ * a [[scalismo.ui.model.SceneNode]].
  */
 trait PropertyPanel extends CardPanel.ComponentWithUniqueId with NodeListFilters {
   /** human-readable description, used in tabs. */

--- a/src/main/scala/scalismo/ui/view/properties/PropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/PropertyPanel.scala
@@ -70,7 +70,7 @@ object PropertyPanel {
 
     import scala.language.implicitConversions
 
-    implicit def factoryAsConstructor(factory: Factory): (ScalismoFrame => PropertyPanel) = {
+    implicit def factoryAsConstructor(factory: Factory): ScalismoFrame => PropertyPanel = {
       factory.create
     }
   }

--- a/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
@@ -18,7 +18,6 @@
 package scalismo.ui.view.properties
 
 import javax.swing.border.TitledBorder
-
 import scalismo.ui.model.SceneNode
 import scalismo.ui.model.properties.{ HasRadius, NodeProperty }
 import scalismo.ui.view.ScalismoFrame

--- a/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
@@ -44,7 +44,7 @@ class RadiusPropertyPanel(override val frame: ScalismoFrame) extends BorderPanel
   private val slider = new FloatSlider(RadiusPropertyPanel.MinValue, RadiusPropertyPanel.MaxValue, RadiusPropertyPanel.StepSize)
 
   layout(new BorderPanel {
-    val sliderPanel = new BorderPanel {
+    private val sliderPanel = new BorderPanel {
       border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
       layout(slider) = BorderPanel.Position.Center
     }

--- a/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
@@ -53,15 +53,15 @@ class RadiusPropertyPanel(override val frame: ScalismoFrame) extends BorderPanel
 
   listenToOwnEvents()
 
-  def listenToOwnEvents() = {
+  def listenToOwnEvents(): Unit = {
     listenTo(slider)
   }
 
-  def deafToOwnEvents() = {
+  def deafToOwnEvents(): Unit = {
     deafTo(slider)
   }
 
-  def updateUi() = {
+  def updateUi(): Unit = {
     deafToOwnEvents()
     targets.headOption.foreach(t => slider.floatValue = t.radius.value.toFloat)
     listenToOwnEvents()

--- a/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
@@ -31,9 +31,9 @@ object RadiusPropertyPanel extends PropertyPanel.Factory {
     new RadiusPropertyPanel(frame)
   }
 
-  var MinValue: Float = 0.0f
-  var MaxValue: Float = 25.0f
-  var StepSize: Float = 0.1f
+  val MinValue: Float = 0.0f
+  val MaxValue: Float = 25.0f
+  val StepSize: Float = 0.1f
 }
 
 class RadiusPropertyPanel(override val frame: ScalismoFrame) extends BorderPanel with PropertyPanel {

--- a/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
@@ -85,7 +85,7 @@ class RadiusPropertyPanel(override val frame: ScalismoFrame) extends BorderPanel
 
   reactions += {
     case NodeProperty.event.PropertyChanged(_) => updateUi()
-    case ValueChanged(c) => targets.foreach(_.radius.value = slider.floatValue.toFloat)
+    case ValueChanged(c) => targets.foreach(_.radius.value = slider.floatValue)
   }
 
 }

--- a/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
@@ -85,7 +85,7 @@ class RadiusPropertyPanel(override val frame: ScalismoFrame) extends BorderPanel
 
   reactions += {
     case NodeProperty.event.PropertyChanged(_) => updateUi()
-    case ValueChanged(c) => targets.foreach(_.radius.value = slider.floatValue)
+    case ValueChanged(_) => targets.foreach(_.radius.value = slider.floatValue)
   }
 
 }

--- a/src/main/scala/scalismo/ui/view/properties/RigidTransformationPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RigidTransformationPropertyPanel.scala
@@ -39,7 +39,7 @@ class RigidTransformationPropertyPanel(override val frame: ScalismoFrame) extend
 
   private var targets: List[TransformationNode[RigidTransformation[_3D]]] = Nil
 
-  val textFields = Array.fill(6)(new TextField())
+  private val textFields = Array.fill(6)(new TextField())
   val labels = List("T1", "T2", "T3", "R1", "R2", "R3")
   val centerLabel = new Label("-")
 
@@ -48,7 +48,7 @@ class RigidTransformationPropertyPanel(override val frame: ScalismoFrame) extend
 
     var (x, y) = (0, 0)
 
-    def next = {
+    private def next: Constraints = {
       constraints.gridx = x
       constraints.gridy = y
 

--- a/src/main/scala/scalismo/ui/view/properties/RigidTransformationPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RigidTransformationPropertyPanel.scala
@@ -17,9 +17,8 @@
 
 package scalismo.ui.view.properties
 
-import javax.swing.border.TitledBorder
-
 import breeze.linalg.DenseVector
+import javax.swing.border.TitledBorder
 import scalismo.geometry._3D
 import scalismo.registration.{ RigidTransformation, RigidTransformationSpace }
 import scalismo.ui.model._

--- a/src/main/scala/scalismo/ui/view/properties/RigidTransformationPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RigidTransformationPropertyPanel.scala
@@ -43,7 +43,7 @@ class RigidTransformationPropertyPanel(override val frame: ScalismoFrame) extend
   val labels = List("T1", "T2", "T3", "R1", "R2", "R3")
   val centerLabel = new Label("-")
 
-  val panel = new GridBagPanel {
+  val panel: GridBagPanel = new GridBagPanel {
     val constraints = new Constraints()
 
     var (x, y) = (0, 0)

--- a/src/main/scala/scalismo/ui/view/properties/RigidTransformationPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RigidTransformationPropertyPanel.scala
@@ -109,7 +109,7 @@ class RigidTransformationPropertyPanel(override val frame: ScalismoFrame) extend
     border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
   }) = BorderPanel.Position.North
 
-  def updateUi() = {
+  def updateUi(): Unit = {
     targets.headOption.foreach { node =>
       val params = node.transformation.translation.parameters.toArray ++ node.transformation.rotation.parameters.toArray
       params.zip(textFields).foreach {

--- a/src/main/scala/scalismo/ui/view/properties/ScalarRangePropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/ScalarRangePropertyPanel.scala
@@ -76,11 +76,11 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
 
   listenToOwnEvents()
 
-  def listenToOwnEvents() = {
+  def listenToOwnEvents(): Unit = {
     listenTo(minimumSlider, maximumSlider)
   }
 
-  def deafToOwnEvents() = {
+  def deafToOwnEvents(): Unit = {
     deafTo(minimumSlider, maximumSlider)
   }
 
@@ -100,7 +100,7 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
     v * step + min
   }
 
-  def updateUi() = {
+  def updateUi(): Unit = {
     deafToOwnEvents()
     targets.foreach { t =>
       min = t.scalarRange.value.absoluteMinimum
@@ -108,7 +108,7 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
       step = (max - min) / 100.0f
 
       // this is an ugly workaround to make sure (min, max) values are properly displayed
-      def reinitSlider(s: FancySlider) = {
+      def reinitSlider(s: FancySlider): Unit = {
         s.min = 1
         s.min = 0
         s.max = 99

--- a/src/main/scala/scalismo/ui/view/properties/ScalarRangePropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/ScalarRangePropertyPanel.scala
@@ -63,7 +63,7 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
   }
 
   {
-    val northedPanel = new BorderPanel {
+    val northedPanel: BorderPanel = new BorderPanel {
       val slidersPanel = new BorderPanel {
         border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
         layout(minimumSlider) = BorderPanel.Position.North

--- a/src/main/scala/scalismo/ui/view/properties/ScalarRangePropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/ScalarRangePropertyPanel.scala
@@ -64,7 +64,7 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
 
   {
     val northedPanel: BorderPanel = new BorderPanel {
-      val slidersPanel = new BorderPanel {
+      private val slidersPanel = new BorderPanel {
         border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
         layout(minimumSlider) = BorderPanel.Position.North
         layout(maximumSlider) = BorderPanel.Position.Center

--- a/src/main/scala/scalismo/ui/view/properties/ScalarRangePropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/ScalarRangePropertyPanel.scala
@@ -18,8 +18,8 @@
 package scalismo.ui.view.properties
 
 import java.awt.Color
-import javax.swing.border.TitledBorder
 
+import javax.swing.border.TitledBorder
 import scalismo.ui.model.SceneNode
 import scalismo.ui.model.properties.{ HasScalarRange, NodeProperty }
 import scalismo.ui.view.ScalismoFrame
@@ -114,6 +114,7 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
         s.max = 99
         s.max = 100
       }
+
       reinitSlider(minimumSlider)
       reinitSlider(maximumSlider)
 

--- a/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
@@ -78,7 +78,7 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
       slider.value
     }
 
-    def update() = {
+    def update(): Unit = {
       val sp = slicingPosition.get
       val (min, max, value) = axis match {
         case Axis.X => (sp.boundingBox.xMin, sp.boundingBox.xMax, sp.x)
@@ -149,7 +149,7 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
     }
   }
 
-  def cleanup() = {
+  def cleanup(): Unit = {
     slicingPosition.foreach(sp => deafTo(sp))
     slicingPosition = None
   }
@@ -164,11 +164,11 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
     }
   }
 
-  def deafToOwnEvents() = {
+  def deafToOwnEvents(): Unit = {
     deafTo(x.slider, y.slider, z.slider, slicesVisible)
   }
 
-  def listenToOwnEvents() = {
+  def listenToOwnEvents(): Unit = {
     listenTo(x.slider, y.slider, z.slider, slicesVisible)
   }
 

--- a/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
@@ -69,7 +69,7 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
       }
     })
 
-    val control = new BorderPanel {
+    val control: BorderPanel = new BorderPanel {
       layout(minus) = BorderPanel.Position.West
       layout(slider) = BorderPanel.Position.Center
       layout(plus) = BorderPanel.Position.East

--- a/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
@@ -18,8 +18,8 @@
 package scalismo.ui.view.properties
 
 import java.awt.Font
-import javax.swing.border.TitledBorder
 
+import javax.swing.border.TitledBorder
 import scalismo.ui.control.SlicingPosition
 import scalismo.ui.model.{ Axis, Scene, SceneNode }
 import scalismo.ui.view.ScalismoFrame

--- a/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
@@ -99,7 +99,7 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
 
   private def axisControls = Seq(x, y, z)
 
-  val position = new GridBagPanel {
+  private class PositionPanel extends GridBagPanel {
     border = new TitledBorder(null, "Position", TitledBorder.LEADING, 0, null, null)
 
     def add(comp: Component, position: (Int, Int)): Unit = {
@@ -120,6 +120,9 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
       add(axis.control, (1, row))
     }
   }
+
+  private val position = new PositionPanel()
+
   position.add(x, 1)
   position.add(y, 2)
   position.add(z, 3)

--- a/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
@@ -39,11 +39,12 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
   private var slicingPosition: Option[SlicingPosition] = None
 
   private[SlicingPositionPanel] class AxisControl(axis: Axis) {
-    val nameLabel = new Label(axis.toString) {
+    val nameLabel: Label = new Label(axis.toString) {
       foreground = AxisColor.forAxis(axis).darker()
       font = font.deriveFont(font.getStyle | Font.BOLD)
     }
-    val slider = new FancySlider {
+
+    val slider: FancySlider = new FancySlider {
 
       min = 0
       max = 0
@@ -125,7 +126,7 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
 
   val slicesVisible = new CheckBox("Show bounding box and slices")
 
-  val visibilityPanel = new BorderPanel {
+  private val visibilityPanel = new BorderPanel {
     border = new TitledBorder(null, "Visibility", TitledBorder.LEADING, 0, null, null)
     layout(slicesVisible) = BorderPanel.Position.Center
   }

--- a/src/main/scala/scalismo/ui/view/properties/WindowLevelPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/WindowLevelPropertyPanel.scala
@@ -19,9 +19,9 @@ package scalismo.ui.view.properties
 
 import java.awt.Color
 import java.awt.image.BufferedImage
+
 import javax.swing.border.TitledBorder
 import javax.swing.{ BorderFactory, JComponent }
-
 import scalismo.ui.model.properties.NodeProperty
 import scalismo.ui.model.{ ImageNode, SceneNode }
 import scalismo.ui.view.ScalismoFrame

--- a/src/main/scala/scalismo/ui/view/properties/WindowLevelPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/WindowLevelPropertyPanel.scala
@@ -188,9 +188,9 @@ class WindowLevelPropertyPanel(override val frame: ScalismoFrame) extends Border
   // layout
   {
     val inset = 10.scaled
-    val northedPanel = new BorderPanel {
+    val northedPanel: BorderPanel = new BorderPanel {
       border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
-      val slidersPanel = new GridBagPanel {
+      val slidersPanel: GridBagPanel = new GridBagPanel {
         val constraints = new Constraints() {
           ipadx = inset
         }

--- a/src/main/scala/scalismo/ui/view/properties/WindowLevelPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/WindowLevelPropertyPanel.scala
@@ -191,7 +191,7 @@ class WindowLevelPropertyPanel(override val frame: ScalismoFrame) extends Border
     val northedPanel: BorderPanel = new BorderPanel {
       border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
       val slidersPanel: GridBagPanel = new GridBagPanel {
-        val constraints = new Constraints() {
+        private val constraints = new Constraints() {
           ipadx = inset
         }
         var (x, y) = (0, 0)
@@ -225,7 +225,7 @@ class WindowLevelPropertyPanel(override val frame: ScalismoFrame) extends Border
         add(windowSlider, next)
       }
 
-      val showitWrap = new BorderPanel {
+      private val showitWrap = new BorderPanel {
         layout(Component.wrap(showit)) = BorderPanel.Position.Center
         border = {
           val line = BorderFactory.createLineBorder(Color.DARK_GRAY, 3.scaled, true)

--- a/src/main/scala/scalismo/ui/view/swing/ExpandablePane.scala
+++ b/src/main/scala/scalismo/ui/view/swing/ExpandablePane.scala
@@ -20,6 +20,7 @@ package scalismo.ui.view.swing
 import java.awt.event.{ MouseAdapter, MouseEvent }
 import java.awt.{ Container, Dimension }
 
+import javax.swing.plaf.basic.BasicSplitPaneDivider
 import javax.swing.{ JComponent, JSplitPane }
 
 object ExpandablePane {
@@ -110,7 +111,7 @@ class ExpandablePane(orientation: Int, leftOrTop: java.awt.Component) extends JS
 
   private trait BasicUIOverrides extends javax.swing.plaf.basic.BasicSplitPaneUI {
 
-    override def createDefaultDivider = {
+    override def createDefaultDivider: BasicSplitPaneDivider = {
       val divider = super.createDefaultDivider
       divider.addMouseListener(new MouseAdapter {
         override def mousePressed(e: MouseEvent): Unit = {

--- a/src/main/scala/scalismo/ui/view/swing/ExpandablePane.scala
+++ b/src/main/scala/scalismo/ui/view/swing/ExpandablePane.scala
@@ -44,7 +44,7 @@ class ExpandablePane(orientation: Int, leftOrTop: java.awt.Component) extends JS
   // indicates if the component is deemed to be functional at all. In case it isn't,
   // the drag handle will still be displayed, but simply won't have any effect.
   val operational: Boolean = getUI match {
-    case synth: javax.swing.plaf.synth.SynthSplitPaneUI =>
+    case _: javax.swing.plaf.synth.SynthSplitPaneUI =>
       setUI(new SynthUI)
       true
     case _ =>

--- a/src/main/scala/scalismo/ui/view/swing/ExpandablePane.scala
+++ b/src/main/scala/scalismo/ui/view/swing/ExpandablePane.scala
@@ -19,6 +19,7 @@ package scalismo.ui.view.swing
 
 import java.awt.event.{ MouseAdapter, MouseEvent }
 import java.awt.{ Container, Dimension }
+
 import javax.swing.{ JComponent, JSplitPane }
 
 object ExpandablePane {
@@ -95,6 +96,7 @@ class ExpandablePane(orientation: Int, leftOrTop: java.awt.Component) extends JS
         val parent = current.getParent
         if (parent == null) current else containing(parent)
       }
+
       val fake = containing(this).getSize
 
       if (isVertical) {

--- a/src/main/scala/scalismo/ui/view/util/CardPanel.scala
+++ b/src/main/scala/scalismo/ui/view/util/CardPanel.scala
@@ -73,7 +73,7 @@ class CardPanel extends Panel with LayoutContainer {
   private var cards: Map[UniqueID, ComponentWithUniqueId] = Map.empty
   private var _current: UniqueID = CardPanel.NoCard
 
-  protected def areValid(c: UniqueID) = (true, "")
+  protected def areValid(c: UniqueID): (Boolean, UniqueID) = (true, "")
 
   def add(card: ComponentWithUniqueId): Unit = {
     add(card, card.uniqueId)
@@ -111,7 +111,7 @@ class CardPanel extends Panel with LayoutContainer {
 
   def currentComponent: ComponentWithUniqueId = cards(_current)
 
-  protected def constraintsFor(comp: Component) = cards.iterator.find {
+  protected def constraintsFor(comp: Component): UniqueID = cards.iterator.find {
     case (_, c) => c eq comp
   }.map(_._1).orNull
 

--- a/src/main/scala/scalismo/ui/view/util/CardPanel.scala
+++ b/src/main/scala/scalismo/ui/view/util/CardPanel.scala
@@ -68,7 +68,7 @@ class CardPanel extends Panel with LayoutContainer {
 
   override lazy val peer = new javax.swing.JPanel(new CustomCardLayout) with SuperMixin
 
-  val layoutManager = peer.getLayout.asInstanceOf[CustomCardLayout]
+  private val layoutManager = peer.getLayout.asInstanceOf[CustomCardLayout]
 
   private var cards: Map[UniqueID, ComponentWithUniqueId] = Map.empty
   private var _current: UniqueID = CardPanel.NoCard

--- a/src/main/scala/scalismo/ui/view/util/CardPanel.scala
+++ b/src/main/scala/scalismo/ui/view/util/CardPanel.scala
@@ -33,6 +33,9 @@ object CardPanel {
   }
 
   class CustomCardLayout extends CardLayout {
+    private val minimumWidth = 0
+    private val minimumHeight = 0
+
     override def preferredLayoutSize(parent: awt.Container): Dimension = {
       if (activeCards.isDefined) {
         parent.getTreeLock synchronized {
@@ -53,8 +56,6 @@ object CardPanel {
     }
 
     private[CardPanel] var activeCards: Option[List[AComponent]] = None
-    var minimumWidth = 0
-    var minimumHeight = 0
   }
 
   val NoCard: String = null

--- a/src/main/scala/scalismo/ui/view/util/Constants.scala
+++ b/src/main/scala/scalismo/ui/view/util/Constants.scala
@@ -20,12 +20,19 @@ package scalismo.ui.view.util
 import java.awt.Color
 
 /**
+ * User Interface Constants
+ *
  * The values in here are constants, in the sense that they're not supposed to change while an
  * application is running. However, they are still defined as vars, to allow developers to
  * easily override them if needed. If that is done, it should be done as early as possible
  * (e.g. in the main method), before an actual instance of the UI is created.
  */
 object Constants {
+
+  /* Note: the following line suppresses "var could be a val" warnings from IntelliJ IDEA.
+  * //noinspection VarCouldBeVal
+  * It is prepended to all definitions, because they are intentionally vars instead of vals.
+  */
 
   /**
    * This is the color value that is used as the basic background color when presenting color selections.
@@ -36,11 +43,13 @@ object Constants {
    * The only place where this is currently used is in the [[scalismo.ui.view.properties.ColorPropertyPanel]] class.
    *
    */
+  //noinspection VarCouldBeVal
   var PerceivedBackgroundColor: Color = Color.GRAY
 
   /**
    * This is the default size of icons, *before* any scaling is applied.
    */
+  //noinspection VarCouldBeVal
   var StandardUnscaledIconSize: Int = 16
 
   /**
@@ -48,6 +57,7 @@ object Constants {
    * This seems to be baked in deeply in all of the Swing internals, so
    * DO NOT CHANGE THIS VALUE unless you REALLY know what you are doing.
    */
+  //noinspection VarCouldBeVal
   var DefaultFontSize: Int = 12
 
 }

--- a/src/main/scala/scalismo/ui/view/util/EnhancedFileChooser.scala
+++ b/src/main/scala/scalismo/ui/view/util/EnhancedFileChooser.scala
@@ -102,13 +102,13 @@ class EnhancedFileChooser(dir: File) extends FileChooser(dir) {
       val model = new DefaultListModel[FileEntry]()
       lastDirs.foreach(d => model.addElement(new FileEntry(d)))
 
-      val panel = new BorderPanel {
+      val panel: BorderPanel = new BorderPanel {
         val title = new BorderPanel {
           layout(new Label("Recent Folders:")) = BorderPanel.Position.West
         }
         layout(title) = BorderPanel.Position.North
 
-        val list = new JList(model) {
+        val list: JList[FileEntry] = new JList(model) {
           def affectedItem(point: Point): Option[FileEntry] = {
             val index = locationToIndex(point)
             if (index > -1 && getCellBounds(index, index).contains(point)) {

--- a/src/main/scala/scalismo/ui/view/util/EnhancedFileChooser.scala
+++ b/src/main/scala/scalismo/ui/view/util/EnhancedFileChooser.scala
@@ -62,13 +62,13 @@ class EnhancedFileChooser(dir: File) extends FileChooser(dir) {
     }
   }
 
-  override def selectedFiles = {
+  override def selectedFiles: Seq[File] = {
     val r = super.selectedFiles
     lastUsedDirectories = r
     r
   }
 
-  override def selectedFile = {
+  override def selectedFile: File = {
     val r = super.selectedFile
     lastUsedDirectories = Seq(r)
     r
@@ -87,9 +87,9 @@ class EnhancedFileChooser(dir: File) extends FileChooser(dir) {
   private[EnhancedFileChooser] class EnhancedJFileChooser extends JFileChooser {
 
     private[EnhancedJFileChooser] class FileEntry(val dir: File) {
-      override def toString = dir.getName
+      override def toString: String = dir.getName
 
-      def tooltip = dir.getCanonicalPath
+      def tooltip: String = dir.getCanonicalPath
     }
 
     override def createDialog(parent: AComponent): JDialog = {
@@ -103,7 +103,7 @@ class EnhancedFileChooser(dir: File) extends FileChooser(dir) {
       lastDirs.foreach(d => model.addElement(new FileEntry(d)))
 
       val panel: BorderPanel = new BorderPanel {
-        val title = new BorderPanel {
+        private val title = new BorderPanel {
           layout(new Label("Recent Folders:")) = BorderPanel.Position.West
         }
         layout(title) = BorderPanel.Position.North
@@ -149,7 +149,7 @@ class EnhancedFileChooser(dir: File) extends FileChooser(dir) {
       else Some(createRecentDirsPanel(l))
     }
 
-    def decorateDialog(dialog: JDialog) = {
+    private def decorateDialog(dialog: JDialog): JDialog = {
       val cp = dialog.getContentPane
       leftComponent match {
         case Some(c) => cp.add(c.peer, BorderLayout.WEST)

--- a/src/main/scala/scalismo/ui/view/util/EnhancedFileChooser.scala
+++ b/src/main/scala/scalismo/ui/view/util/EnhancedFileChooser.scala
@@ -20,8 +20,8 @@ package scalismo.ui.view.util
 import java.awt.event.{ MouseAdapter, MouseEvent, MouseMotionAdapter }
 import java.awt.{ BorderLayout, Color, Point, Component => AComponent }
 import java.io.File
-import javax.swing._
 
+import javax.swing._
 import scalismo.ui.settings.GlobalSettings
 import scalismo.ui.view.util.ScalableUI.implicits.scalableInt
 

--- a/src/main/scala/scalismo/ui/view/util/EnhancedFileChooser.scala
+++ b/src/main/scala/scalismo/ui/view/util/EnhancedFileChooser.scala
@@ -29,7 +29,7 @@ import scala.swing.{ BorderPanel, Component, FileChooser, Label }
 import scala.util.Failure
 
 object EnhancedFileChooser {
-  var MaxDirs = 13
+  val MaxDirs = 13
 }
 
 /*

--- a/src/main/scala/scalismo/ui/view/util/EnhancedFileChooser.scala
+++ b/src/main/scala/scalismo/ui/view/util/EnhancedFileChooser.scala
@@ -50,7 +50,7 @@ class EnhancedFileChooser(dir: File) extends FileChooser(dir) {
     }
   }
 
-  def lastUsedDirectories_=(files: Seq[File]) = {
+  def lastUsedDirectories_=(files: Seq[File]): Unit = {
     val dirs = files.map(f => if (f.isDirectory) f else f.getParentFile).distinct
     if (dirs.nonEmpty) {
       val old = lastUsedDirectories.diff(dirs)
@@ -74,12 +74,12 @@ class EnhancedFileChooser(dir: File) extends FileChooser(dir) {
     r
   }
 
-  override def selectedFiles_=(files: File*) = {
+  override def selectedFiles_=(files: File*): Unit = {
     lastUsedDirectories = files
     super.selectedFiles_=(files: _*)
   }
 
-  override def selectedFile_=(file: File) = {
+  override def selectedFile_=(file: File): Unit = {
     lastUsedDirectories = Seq(file)
     super.selectedFile_=(file)
   }
@@ -119,7 +119,7 @@ class EnhancedFileChooser(dir: File) extends FileChooser(dir) {
           }
 
           addMouseMotionListener(new MouseMotionAdapter {
-            override def mouseMoved(e: MouseEvent) = {
+            override def mouseMoved(e: MouseEvent): Unit = {
               affectedItem(e.getPoint) match {
                 case None => setToolTipText(null)
                 case Some(f) => setToolTipText(f.tooltip)
@@ -128,7 +128,7 @@ class EnhancedFileChooser(dir: File) extends FileChooser(dir) {
           })
 
           addMouseListener(new MouseAdapter {
-            override def mouseClicked(e: MouseEvent) = {
+            override def mouseClicked(e: MouseEvent): Unit = {
               if (e.getClickCount >= 2 && e.getButton == MouseEvent.BUTTON1) {
                 affectedItem(e.getPoint).foreach(f => EnhancedJFileChooser.this.setCurrentDirectory(f.dir))
               }

--- a/src/main/scala/scalismo/ui/view/util/FancySlider.scala
+++ b/src/main/scala/scalismo/ui/view/util/FancySlider.scala
@@ -28,15 +28,15 @@ class FancySlider extends Slider {
 
   // The labels are protected so that subclasses can override properties like color etc.
   // When setting the visible property of a label to false, it won't be shown on the slider (duh! :-) )
-  protected val minLabel = new Label {
+  protected val minLabel: Label = new Label {
     foreground = Color.GRAY
   }
 
-  protected val maxLabel = new Label {
+  protected val maxLabel: Label = new Label {
     foreground = Color.GRAY
   }
 
-  protected val valueLabel = new Label {
+  protected val valueLabel: Label = new Label {
     foreground = Color.BLACK
   }
 

--- a/src/main/scala/scalismo/ui/view/util/FloatSlider.scala
+++ b/src/main/scala/scalismo/ui/view/util/FloatSlider.scala
@@ -28,7 +28,7 @@ class FloatSlider(val minFloat: Float, val maxFloat: Float, val stepFloat: Float
     minFloat + stepFloat * i
   }
 
-  def floatValue = i2f(value)
+  def floatValue: Float = i2f(value)
 
   def floatValue_=(newValue: Float): Unit = value = f2i(newValue)
 

--- a/src/main/scala/scalismo/ui/view/util/FloatSlider.scala
+++ b/src/main/scala/scalismo/ui/view/util/FloatSlider.scala
@@ -30,7 +30,7 @@ class FloatSlider(val minFloat: Float, val maxFloat: Float, val stepFloat: Float
 
   def floatValue = i2f(value)
 
-  def floatValue_=(newValue: Float) = value = f2i(newValue)
+  def floatValue_=(newValue: Float): Unit = value = f2i(newValue)
 
   min = 0
   max = ((maxFloat - minFloat) / stepFloat).toInt

--- a/src/main/scala/scalismo/ui/view/util/LinkLabel.scala
+++ b/src/main/scala/scalismo/ui/view/util/LinkLabel.scala
@@ -20,6 +20,7 @@ package scalismo.ui.view.util
 import java.awt.event.{ MouseAdapter, MouseEvent }
 import java.awt.{ Color, Cursor, Desktop }
 import java.net.URI
+
 import javax.swing.Icon
 
 import scala.swing.Swing.EmptyIcon

--- a/src/main/scala/scalismo/ui/view/util/MultiLineLabel.scala
+++ b/src/main/scala/scalismo/ui/view/util/MultiLineLabel.scala
@@ -18,6 +18,7 @@
 package scalismo.ui.view.util
 
 import java.awt.Color
+
 import javax.swing.{ BorderFactory, UIManager }
 
 import scala.swing.TextArea

--- a/src/main/scala/scalismo/ui/view/util/MultiLineLabel.scala
+++ b/src/main/scala/scalismo/ui/view/util/MultiLineLabel.scala
@@ -31,7 +31,7 @@ class MultiLineLabel(text: String) extends TextArea(text) {
   peer.setOpaque(false)
   peer.setFocusable(false)
   peer.setBackground(new Color(UIManager.getColor("control").getRGB))
-  val hv = ScalableUI.scale(10)
+  private val hv = ScalableUI.scale(10)
   peer.setBorder(BorderFactory.createEmptyBorder(hv, hv, hv, hv))
 
 }

--- a/src/main/scala/scalismo/ui/view/util/ScalableUI.scala
+++ b/src/main/scala/scalismo/ui/view/util/ScalableUI.scala
@@ -18,9 +18,9 @@
 package scalismo.ui.view.util
 
 import java.awt.{ Dimension, Font, GraphicsEnvironment, Transparency }
+
 import javax.swing.plaf.FontUIResource
 import javax.swing.{ Icon, ImageIcon, UIDefaults, UIManager }
-
 import scalismo.ui.resources.icons.ScalableIcon
 import scalismo.ui.settings.GlobalSettings
 


### PR DESCRIPTION
This PR consists of mostly cosmetic changes, with the goal of having as "clean" a codebase as reasonably possible.

There should be no difference whatsoever in terms of functionality or behavior, but IntelliJ IDEA should now happily show green checkmarks on all source files, and sbt should emit at most one warning (requesting that Build.scala be turned into an sbt file).

In other words: using IDEA's "Analyze - Inspect Code" functionality on the src folder with the default settings should not report any issues at all (except for "spelling/typos", which is the most useless inspection ever).

Here's what I did:

- updated Scala, scalariform and sbt-assembly versions, and rewrote deprecated stuff
- minor reformattings: whitespace, optimization of imports
- fixed all sbt and IntelliJ IDEA warnings (missing type declarations, unused variables etc.)

While this is a rather big diff, all of the changes are straightforward and easy to understand.

In very few cases, I minimally refactored parameter and method names to be more understandable, or had to turn an anonymous class definition into an explicit one.

**NOTE**: a few fields and methods have been turned from public to private. I believe that this should not break anything, because they were never intended for public use, and I don't see a reason why anything would have used them. However, I can't give a 100% guarantee -- there is still a minimal chance that dependent projects could break. I guess the only way is to try and see.

I tested this as far as I could, but still: please carefully review this PR  -- criticism and discussions are welcome. That said, I'd like to see this merged rather sooner than later, because I think that it was worth the effort, and that the result will provide a solid base for further improvements.

Cheers,

Christoph