### PR TITLE
added possibility to nest group into groups

### DIFF
--- a/src/main/scala/scalismo/ui/api/SimpleAPI.scala
+++ b/src/main/scala/scalismo/ui/api/SimpleAPI.scala
@@ -21,6 +21,8 @@ trait SimpleAPI {
 
   def createGroup(groupName: String): Group
 
+  def createGroup(group: Group, groupName: String): Group
+
   def show[A](a: A, name: String)(implicit showInScene: ShowInScene[A]): showInScene.View
 
   def show[A](group: Group, a: A, name: String)(implicit showInScene: ShowInScene[A]): showInScene.View

--- a/src/main/scala/scalismo/ui/api/SimpleAPIDefaultImpl.scala
+++ b/src/main/scala/scalismo/ui/api/SimpleAPIDefaultImpl.scala
@@ -25,7 +25,13 @@ trait SimpleAPIDefaultImpl {
 
   protected[api] def scene: Scene
 
-  override def createGroup(groupName: String): Group = Group(scene.groups.add(groupName))
+  override def createGroup(groupName: String): Group = {
+    Group(scene.groups.add(groupName))
+  }
+
+  override def createGroup(group: Group, groupName: String): Group = {
+    Group(group.peer.groups.add(groupName))
+  }
 
   override def show[A](a: A, name: String)(implicit showInScene: ShowInScene[A]): showInScene.View = showInScene.showInScene(a, name, defaultGroup)
 

--- a/src/main/scala/scalismo/ui/model/GroupNode.scala
+++ b/src/main/scala/scalismo/ui/model/GroupNode.scala
@@ -22,7 +22,7 @@ import scalismo.ui.event.ScalismoPublisher
 import scalismo.ui.model.Scene.event.SceneChanged
 import scalismo.ui.model.capabilities.{ Removeable, Renameable }
 
-class GroupsNode(override val parent: Scene) extends SceneNodeCollection[GroupNode] {
+class GroupsNode(override val parent: SceneNode) extends SceneNodeCollection[GroupNode] {
   override val name = "Groups"
 
   def add(name: String, hidden: Boolean = false): GroupNode = {
@@ -49,7 +49,7 @@ class GroupNode(override val parent: GroupsNode, initialName: String, initallyHi
 
   val genericTransformations = new GenericTransformationsNode(this)
   val shapeModelTransformations = new ShapeModelTransformationsNode(this)
-
+  val groups = new GroupsNode(this)
   val landmarks = new LandmarksNode(this)
   val triangleMeshes = new TriangleMeshesNode(this)
   val colorMeshes = new VertexColorMeshesNode(this)
@@ -61,6 +61,7 @@ class GroupNode(override val parent: GroupsNode, initialName: String, initallyHi
   val scalarFields = new ScalarFieldsNode(this)
 
   override val children: List[SceneNode] = List(
+    groups,
     genericTransformations,
     shapeModelTransformations,
     landmarks,
@@ -88,6 +89,10 @@ class GroupNode(override val parent: GroupsNode, initialName: String, initallyHi
     shapeModelTransformations.addPoseTransformation(PointTransformation.RigidIdentity)
     shapeModelTransformations.addGaussianProcessTransformation(DiscreteLowRankGpPointTransformation(model.gp))
 
+  }
+
+  def addGroup(s: String) = {
+    groups.add(s)
   }
 
   override def remove(): Unit = parent.remove(this)

--- a/src/main/scala/scalismo/ui/model/TransformationNode.scala
+++ b/src/main/scala/scalismo/ui/model/TransformationNode.scala
@@ -64,8 +64,16 @@ class GenericTransformationsNode(override val parent: GroupNode) extends Transfo
     node
   }
 
+  def parentTransformations: PointTransformation = {
+    if (parent != null && parent.parent != null && parent.parent.parent != null && parent.parent.parent.isInstanceOf[GroupNode]) {
+      parent.parent.parent.asInstanceOf[GroupNode].genericTransformations.combinedTransformation
+    } else {
+      PointTransformation.RigidIdentity
+    }
+  }
+
   def combinedTransformation: PointTransformation = {
-    val transforms = children.map(_.transformation.asInstanceOf[PointTransformation])
+    val transforms = children.map(_.transformation.asInstanceOf[PointTransformation]) :+ parentTransformations
     transforms.foldLeft(PointTransformation.Identity: PointTransformation) { case (first, second) => first compose second }
   }
 

--- a/src/main/scala/scalismo/ui/model/capabilities/Transformable.scala
+++ b/src/main/scala/scalismo/ui/model/capabilities/Transformable.scala
@@ -18,7 +18,7 @@
 package scalismo.ui.model.capabilities
 
 import scalismo.ui.event.Event
-import scalismo.ui.model.{ GenericTransformationsNode, PointTransformation, ShapeModelTransformationsNode }
+import scalismo.ui.model._
 
 object Transformable {
 
@@ -37,8 +37,10 @@ trait Transformable[T] extends RenderableSceneNode with Grouped {
 
   private def shapeModelTransformationsNode: ShapeModelTransformationsNode = group.shapeModelTransformations
 
-  private def combinedTransform = shapeModelTransformationsNode.combinedTransformation.map(smT => genericTransformationsNode.combinedTransformation compose smT) getOrElse {
-    genericTransformationsNode.combinedTransformation
+  private def combinedTransform = {
+    shapeModelTransformationsNode.combinedTransformation.map(smT => genericTransformationsNode.combinedTransformation compose smT) getOrElse {
+      genericTransformationsNode.combinedTransformation
+    }
   }
 
   private var _transformedSource = transform(source, combinedTransform)
@@ -50,6 +52,15 @@ trait Transformable[T] extends RenderableSceneNode with Grouped {
   def updateTransformedSource(): Unit = {
     _transformedSource = transform(source, combinedTransform)
     publishEvent(Transformable.event.GeometryChanged(this))
+  }
+
+  var p: SceneNode = parent
+  while (p != null) {
+    p match {
+      case g: GroupNode => listenTo(g.genericTransformations)
+      case _ => {}
+    }
+    p = p.parent
   }
 
   listenTo(genericTransformationsNode)

--- a/src/main/scala/scalismo/ui/view/action/popup/AddGroupAction.scala
+++ b/src/main/scala/scalismo/ui/view/action/popup/AddGroupAction.scala
@@ -17,20 +17,27 @@
 
 package scalismo.ui.view.action.popup
 
-import scalismo.ui.model.{ Scene, SceneNode }
+import scalismo.ui.model.{ GroupNode, Scene, SceneNode }
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.action.AskForInputAction
 
 object AddGroupAction extends PopupAction.Factory {
   override def apply(context: List[SceneNode])(implicit frame: ScalismoFrame): List[PopupAction] = {
-    singleMatch[Scene](context).map(n => new AddGroupAction(n)).toList
+    singleMatch[Scene](context).map(n => new AddGroupAction(n)).toList ++
+      singleMatch[GroupNode](context).map(n => new AddGroupAction(n)).toList
   }
 }
 
-class AddGroupAction(node: Scene)(implicit val frame: ScalismoFrame) extends PopupAction("Add Group ...", BundledIcon.Group) {
+class AddGroupAction(node: SceneNode)(implicit val frame: ScalismoFrame) extends PopupAction("Add Group ...", BundledIcon.Group) {
   def callback(newName: Option[String]): Unit = {
-    newName.foreach(n => node.groups.add(n))
+
+    node match {
+      case sceneNode: Scene => newName.foreach(n => sceneNode.groups.add(n))
+      case groupNode: GroupNode => {
+        newName.foreach(n => groupNode.addGroup(n))
+      }
+    }
   }
 
   override def apply(): Unit = {


### PR DESCRIPTION
The added functionality, which is applicable from both the UI and the
simple API, makes it possible to build a scene graph with transformations
and objects.

Using the API, a nested group is created as follows
```scala
  val group1 = ui.createGroup("group1")
  val group2 = ui.createGroup(group1, "Nested group")
```

#### Warning: 
- This is a first implementation and has not been extensively tested. Its purpose is to let interested people try it out for real scenarios. Applicability in practice should be shown before it is merged
- There is at least one limitation: The mechanism allows to add StatisticalShapeModelTransformations at any level in the hierarchy. This works technically, but makes mathematically no sense currently. 