### PR TITLE
use templates in conversion of tetrahedral meshes to vtk

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -46,7 +46,7 @@ object Creds {
 }
 
 object Dependencies {
-  val scalismo = "ch.unibas.cs.gravis" %% "scalismo" % "0.18-M1"
+  val scalismo = "ch.unibas.cs.gravis" %% "scalismo" % "develop-294ece27618520098ba43adb340875e71e7392ac"
   val scalismoNative = "ch.unibas.cs.gravis" % "scalismo-native-all" % "4.0.0"
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
   val swingPlus = "de.sciss" %% "swingplus" % "0.2.2"

--- a/src/main/scala/scalismo/ui/rendering/Caches.scala
+++ b/src/main/scala/scalismo/ui/rendering/Caches.scala
@@ -42,7 +42,7 @@ object Caches {
 
   case class FastCachingTetrahedralMesh(mesh: TetrahedralMesh3D) {
     override lazy val hashCode: Int =
-      (31 + mesh.pointSet.hashCode()) * (31 + mesh.tetrahedralization.hashCode()) //* 31 + mesh.color.hashCode())
+      (31 + mesh.pointSet.hashCode()) * (31 + mesh.tetrahedralization.hashCode())
   }
 
   final val TriangleMeshCache = new Cache[FastCachingTriangleMesh, vtkPolyData]

--- a/src/main/scala/scalismo/ui/rendering/actor/TetrahedralActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/TetrahedralActor.scala
@@ -35,7 +35,7 @@
 package scalismo.ui.rendering.actor
 
 import scalismo.geometry._3D
-import scalismo.mesh.{ ScalarVolumeMeshField, TetrahedralMesh }
+import scalismo.mesh.{ScalarVolumeMeshField, TetrahedralMesh}
 import scalismo.ui.model._
 import scalismo.ui.model.capabilities.Transformable
 import scalismo.ui.model.properties._
@@ -44,8 +44,8 @@ import scalismo.ui.rendering.Caches.FastCachingTetrahedralMesh
 import scalismo.ui.rendering.actor.TetrahedralActor.TetrahedralRenderable
 import scalismo.ui.rendering.actor.mixin._
 import scalismo.ui.rendering.util.VtkUtil
-import scalismo.ui.view.{ ViewportPanel, ViewportPanel2D, ViewportPanel3D }
-import scalismo.utils.TetrahedralMeshConversion
+import scalismo.ui.view.{ViewportPanel, ViewportPanel2D, ViewportPanel3D}
+import scalismo.utils.{MeshConversion, TetrahedralMeshConversion}
 import vtk.vtkUnstructuredGrid
 
 object TetrahedralMeshActor extends SimpleActorsFactory[TetrahedralMeshNode] {
@@ -136,7 +136,7 @@ trait TetrahedralActor[R <: TetrahedralRenderable] extends SingleDataSetActor wi
 
   protected def rerender(geometryChanged: Boolean): Unit = {
     if (geometryChanged) {
-      unstructuredgrid = meshToUnstructuredGrid(None)
+      unstructuredgrid = meshToUnstructuredGrid(Some(unstructuredgrid))
       onGeometryChanged()
     }
 
@@ -176,7 +176,8 @@ trait TetrahedralMeshActor extends TetrahedralActor[TetrahedralRenderable.Tetrah
   override def color: ColorProperty = renderable.color
 
   override protected def meshToUnstructuredGrid(template: Option[vtkUnstructuredGrid]): vtkUnstructuredGrid = {
-    Caches.TetrahedralMeshCache.getOrCreate(FastCachingTetrahedralMesh(renderable.mesh), TetrahedralMeshConversion.tetrahedralMeshToVTKUnstructuredGrid(renderable.mesh))
+    Caches.TetrahedralMeshCache.getOrCreate(FastCachingTetrahedralMesh(renderable.mesh),
+      TetrahedralMeshConversion.tetrahedralMeshToVTKUnstructuredGrid(renderable.mesh, template))
 
   }
 }
@@ -188,7 +189,10 @@ trait TetrahedralMeshScalarFieldActor extends TetrahedralActor[TetrahedralRender
   override def scalarRange: ScalarRangeProperty = renderable.scalarRange
 
   override protected def meshToUnstructuredGrid(template: Option[vtkUnstructuredGrid]): vtkUnstructuredGrid = {
-    Caches.ScalarTetrahedralMeshFieldCache.getOrCreate(renderable.field, TetrahedralMeshConversion.scalarVolumeMeshFieldToVtkUnstructuredGrid(renderable.field))
+    Caches.ScalarTetrahedralMeshFieldCache
+      .getOrCreate(renderable.field,
+        TetrahedralMeshConversion.scalarVolumeMeshFieldToVtkUnstructuredGrid(renderable.field, template)
+      )
   }
 }
 


### PR DESCRIPTION
This PR improves efficiency in the visualization of tetrahedral meshes. This is achieved by providing a template mesh when converting a mesh to vtk. The topology is then taken from this template mesh and does not need to be constructed at every warp. 

*Note! This version depends on an unpublished, development version of Scalismo. Travis will therefore fail and maybe we should wait with merging until we have Scalismo-v018-M2 published.*

