### PR TITLE
Pull out a scaled slider class for finer grained control of slice positions

### DIFF
--- a/src/main/scala/scalismo/ui/control/SlicingPosition.scala
+++ b/src/main/scala/scalismo/ui/control/SlicingPosition.scala
@@ -83,21 +83,21 @@ class SlicingPosition(val scene: Scene, val frame: ScalismoFrame) extends Scalis
 
   def z: Double = point(2)
 
-  def x_=(nv: Float): Unit = {
+  def x_=(nv: Double): Unit = {
     val sv = Math.min(Math.max(boundingBox.xMin, nv), boundingBox.xMax)
     if (x != sv) {
       point_=(Point(sv, y, z))
     }
   }
 
-  def y_=(nv: Float): Unit = {
+  def y_=(nv: Double): Unit = {
     val sv = Math.min(Math.max(boundingBox.yMin, nv), boundingBox.yMax)
     if (y != sv) {
       point = Point(x, sv, z)
     }
   }
 
-  def z_=(nv: Float): Unit = {
+  def z_=(nv: Double): Unit = {
     val sv = Math.min(Math.max(boundingBox.zMin, nv), boundingBox.zMax)
     if (z != sv) {
       point = Point(x, y, sv)

--- a/src/main/scala/scalismo/ui/view/ViewportPanel.scala
+++ b/src/main/scala/scalismo/ui/view/ViewportPanel.scala
@@ -121,18 +121,16 @@ class ViewportPanel3D(frame: ScalismoFrame, override val name: String = "3D") ex
 class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPanel(frame) {
   override def name: String = axis.toString
 
-  private val SubDivisions: Double = 100.0
-
   private lazy val positionSlider = new SubDividedSliderAdapter(new Slider {
     peer.setOrientation(SwingConstants.VERTICAL)
   })
 
   lazy val positionPlusButton = new Button(new Action("+") {
-    override def apply(): Unit = positionSlider.up
+    override def apply(): Unit = positionSlider.up()
   })
 
   lazy val positionMinusButton = new Button(new Action("-") {
-    override def apply(): Unit = positionSlider.down
+    override def apply(): Unit = positionSlider.down()
   })
 
   private lazy val sliderPanel = new BorderPanel {

--- a/src/main/scala/scalismo/ui/view/ViewportPanel.scala
+++ b/src/main/scala/scalismo/ui/view/ViewportPanel.scala
@@ -26,7 +26,7 @@ import scalismo.ui.rendering.{RendererPanel, RendererState}
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.util.FileIoMetadata
 import scalismo.ui.view.action.SaveAction
-import scalismo.ui.view.util.{AxisColor, ScalableUI, SubDividedSliderAdapter}
+import scalismo.ui.view.util.{AxisColor, ScalableUI, TypedSlider, TypedSliderValueChanged}
 
 import scala.swing._
 import scala.swing.event.{Event, ValueChanged}
@@ -121,9 +121,9 @@ class ViewportPanel3D(frame: ScalismoFrame, override val name: String = "3D") ex
 class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPanel(frame) {
   override def name: String = axis.toString
 
-  private lazy val positionSlider = new SubDividedSliderAdapter(new Slider {
-    peer.setOrientation(SwingConstants.VERTICAL)
-  })
+  private lazy val positionSlider = new TypedSlider[Int](true, 0.01) {
+    slider.peer.setOrientation(SwingConstants.VERTICAL)
+  }
 
   lazy val positionPlusButton = new Button(new Action("+") {
     override def apply(): Unit = positionSlider.up()
@@ -152,7 +152,7 @@ class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPane
 
   rendererPanel.border = BorderFactory.createLineBorder(AxisColor.forAxis(axis), ScalableUI.scale(3))
 
-  listenTo(frame.sceneControl.slicingPosition, positionSlider.slider)
+  listenTo(frame.sceneControl.slicingPosition, positionSlider)
 
   def updateSliderValue(p: scalismo.geometry.Point3D): Unit = {
     val v = axis match {
@@ -160,9 +160,9 @@ class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPane
       case Axis.Y => p.y
       case Axis.Z => p.z
     }
-    deafTo(positionSlider.slider)
+    deafTo(positionSlider)
     positionSlider.value = v
-    listenTo(positionSlider.slider)
+    listenTo(positionSlider)
   }
 
   def updateSliderMinMax(b: BoundingBox): Unit = {
@@ -171,10 +171,10 @@ class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPane
       case Axis.Y => (b.yMin, b.yMax)
       case Axis.Z => (b.zMin, b.zMax)
     }
-    deafTo(positionSlider.slider)
+    deafTo(positionSlider)
     positionSlider.min = min
     positionSlider.max = max
-    listenTo(positionSlider.slider)
+    listenTo(positionSlider)
   }
 
   def sliderValueChanged(): Unit = {
@@ -192,6 +192,6 @@ class ViewportPanel2D(frame: ScalismoFrame, val axis: Axis) extends ViewportPane
     case SlicingPosition.event.PerspectiveChanged(s) =>
       updateSliderMinMax(s.boundingBox)
       updateSliderValue(s.point)
-    case ValueChanged(s) if s eq positionSlider.slider => sliderValueChanged()
+    case TypedSliderValueChanged(s) if s eq positionSlider => sliderValueChanged()
   }
 }

--- a/src/main/scala/scalismo/ui/view/dialog/DisplayScalingDialog.scala
+++ b/src/main/scala/scalismo/ui/view/dialog/DisplayScalingDialog.scala
@@ -24,7 +24,7 @@ import javax.swing.BorderFactory
 import scalismo.ui.resources.icons.BundledIcon
 import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.util.ScalableUI.implicits.scalableInt
-import scalismo.ui.view.util.{Constants, FancySlider, ScalableUI}
+import scalismo.ui.view.util.{Constants, ScalableUI, TypedSlider}
 
 import scala.swing._
 import scala.swing.event.ValueChanged
@@ -65,7 +65,7 @@ class DisplayScalingDialog(implicit val frame: ScalismoFrame) extends Dialog(fra
     border = BorderFactory.createEmptyBorder(b, b, b, b)
   }
 
-  private class ScaleSlider extends FancySlider {
+  private class ScaleSlider extends TypedSlider[Int](showLabels = true) {
     min = 25
     max = 400
     value = initialScale
@@ -79,13 +79,13 @@ class DisplayScalingDialog(implicit val frame: ScalismoFrame) extends Dialog(fra
 
   // when the user is done sliding, re-pack the window
 
-  scaleSlider.peer.addMouseListener(new MouseAdapter {
+  scaleSlider.slider.peer.addMouseListener(new MouseAdapter {
     override def mouseReleased(e: MouseEvent): Unit = {
       pack()
     }
   })
 
-  scaleSlider.peer.addKeyListener(new KeyAdapter {
+  scaleSlider.slider.peer.addKeyListener(new KeyAdapter {
     override def keyReleased(e: KeyEvent): Unit = {
       pack()
     }
@@ -118,7 +118,7 @@ class DisplayScalingDialog(implicit val frame: ScalismoFrame) extends Dialog(fra
     case ValueChanged(_) => updateLayout()
   }
 
-  main.layout(scaleSlider) = BorderPanel.Position.North
+  main.layout(scaleSlider.slider) = BorderPanel.Position.North
   main.layout(example) = BorderPanel.Position.Center
   main.layout(new GridPanel(1, 2) {
     contents ++= Seq(cancel, ok)

--- a/src/main/scala/scalismo/ui/view/properties/LineWidthPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/LineWidthPropertyPanel.scala
@@ -21,10 +21,9 @@ import javax.swing.border.TitledBorder
 import scalismo.ui.model.SceneNode
 import scalismo.ui.model.properties.{HasLineWidth, LineWidthProperty, NodeProperty}
 import scalismo.ui.view.ScalismoFrame
-import scalismo.ui.view.util.FancySlider
+import scalismo.ui.view.util.{TypedSlider, TypedSliderValueChanged}
 
 import scala.swing.BorderPanel
-import scala.swing.event.ValueChanged
 
 object LineWidthPropertyPanel extends PropertyPanel.Factory {
   override def create(frame: ScalismoFrame): PropertyPanel = {
@@ -37,7 +36,7 @@ class LineWidthPropertyPanel(override val frame: ScalismoFrame) extends BorderPa
 
   private var targets: List[HasLineWidth] = Nil
 
-  private val slider = new FancySlider {
+  private val slider = new TypedSlider[Int](showLabels = true) {
     min = 1
     max = LineWidthProperty.MaxValue
     value = 1
@@ -46,7 +45,7 @@ class LineWidthPropertyPanel(override val frame: ScalismoFrame) extends BorderPa
   layout(new BorderPanel {
     val sliderPanel: BorderPanel = new BorderPanel {
       border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
-      layout(slider) = BorderPanel.Position.Center
+      layout(slider.slider) = BorderPanel.Position.Center
     }
     layout(sliderPanel) = BorderPanel.Position.Center
   }) = BorderPanel.Position.North
@@ -85,7 +84,7 @@ class LineWidthPropertyPanel(override val frame: ScalismoFrame) extends BorderPa
 
   reactions += {
     case NodeProperty.event.PropertyChanged(_) => updateUi()
-    case ValueChanged(_)                       => targets.foreach(_.lineWidth.value = slider.value)
+    case TypedSliderValueChanged(_)            => targets.foreach(_.lineWidth.value = slider.value)
   }
 
 }

--- a/src/main/scala/scalismo/ui/view/properties/OpacityPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/OpacityPropertyPanel.scala
@@ -21,7 +21,7 @@ import javax.swing.border.TitledBorder
 import scalismo.ui.model.SceneNode
 import scalismo.ui.model.properties.{HasOpacity, NodeProperty}
 import scalismo.ui.view.ScalismoFrame
-import scalismo.ui.view.util.FancySlider
+import scalismo.ui.view.util.{TypedSlider, TypedSliderValueChanged}
 
 import scala.swing.BorderPanel
 import scala.swing.event.ValueChanged
@@ -38,7 +38,7 @@ class OpacityPropertyPanel(override val frame: ScalismoFrame) extends BorderPane
 
   private var targets: List[HasOpacity] = Nil
 
-  private val slider = new FancySlider {
+  private val slider = new TypedSlider[Int](showLabels = true) {
     min = 0
     max = 100
     value = 100
@@ -49,7 +49,7 @@ class OpacityPropertyPanel(override val frame: ScalismoFrame) extends BorderPane
   layout(new BorderPanel {
     private val sliderPanel = new BorderPanel {
       border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
-      layout(slider) = BorderPanel.Position.Center
+      layout(slider.slider) = BorderPanel.Position.Center
     }
     layout(sliderPanel) = BorderPanel.Position.Center
   }) = BorderPanel.Position.North
@@ -88,7 +88,7 @@ class OpacityPropertyPanel(override val frame: ScalismoFrame) extends BorderPane
 
   reactions += {
     case NodeProperty.event.PropertyChanged(_) => updateUi()
-    case ValueChanged(_)                       => targets.foreach(_.opacity.value = slider.value.toFloat / 100.0f)
+    case TypedSliderValueChanged(_)            => targets.foreach(_.opacity.value = slider.value.toFloat / 100.0f)
   }
 
 }

--- a/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/RadiusPropertyPanel.scala
@@ -21,10 +21,9 @@ import javax.swing.border.TitledBorder
 import scalismo.ui.model.SceneNode
 import scalismo.ui.model.properties.{HasRadius, NodeProperty}
 import scalismo.ui.view.ScalismoFrame
-import scalismo.ui.view.util.FloatSlider
+import scalismo.ui.view.util.{TypedSlider, TypedSliderValueChanged}
 
 import scala.swing.BorderPanel
-import scala.swing.event.ValueChanged
 
 object RadiusPropertyPanel extends PropertyPanel.Factory {
   override def create(frame: ScalismoFrame): PropertyPanel = {
@@ -42,12 +41,15 @@ class RadiusPropertyPanel(override val frame: ScalismoFrame) extends BorderPanel
   private var targets: List[HasRadius] = Nil
 
   private val slider =
-    new FloatSlider(RadiusPropertyPanel.MinValue, RadiusPropertyPanel.MaxValue, RadiusPropertyPanel.StepSize)
+    new TypedSlider[Float](stepSize = RadiusPropertyPanel.StepSize) {
+      min = RadiusPropertyPanel.MinValue
+      max = RadiusPropertyPanel.MaxValue
+    }
 
   layout(new BorderPanel {
     private val sliderPanel = new BorderPanel {
       border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
-      layout(slider) = BorderPanel.Position.Center
+      layout(slider.slider) = BorderPanel.Position.Center
     }
     layout(sliderPanel) = BorderPanel.Position.Center
   }) = BorderPanel.Position.North
@@ -64,7 +66,7 @@ class RadiusPropertyPanel(override val frame: ScalismoFrame) extends BorderPanel
 
   def updateUi(): Unit = {
     deafToOwnEvents()
-    targets.headOption.foreach(t => slider.floatValue = t.radius.value.toFloat)
+    targets.headOption.foreach(t => slider.value = t.radius.value)
     listenToOwnEvents()
   }
 
@@ -86,7 +88,7 @@ class RadiusPropertyPanel(override val frame: ScalismoFrame) extends BorderPanel
 
   reactions += {
     case NodeProperty.event.PropertyChanged(_) => updateUi()
-    case ValueChanged(_)                       => targets.foreach(_.radius.value = slider.floatValue)
+    case TypedSliderValueChanged(_)            => targets.foreach(_.radius.value = slider.value)
   }
 
 }

--- a/src/main/scala/scalismo/ui/view/properties/ScalarRangePropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/ScalarRangePropertyPanel.scala
@@ -25,7 +25,7 @@ import scalismo.ui.model.SceneNode
 import scalismo.ui.model.properties.{ColorMapping, HasScalarRange, NodeProperty}
 import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.util.ScalableUI.implicits.scalableInt
-import scalismo.ui.view.util.{FancySlider, MultiLineLabel}
+import scalismo.ui.view.util.{MultiLineLabel, TypedSlider, TypedSliderValueChanged}
 
 import scala.swing.BorderPanel
 import scala.swing.event.ValueChanged
@@ -44,13 +44,13 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
   private var max: Float = 100
   private var step: Float = 1
 
-  private def colorizeSliderValue(slider: FancySlider, color: Color): Unit = {
+  private def colorizeSliderValue(slider: TypedSlider[Int], color: Color): Unit = {
     // Setting the color of the displayed text may result in poor readability for certain colors, so we
     // create an "underline" showing the color instead.
     slider.valueLabel.border = BorderFactory.createMatteBorder(0, 0, 3.scaled, 0, color)
   }
 
-  private val minimumSlider = new FancySlider {
+  private val minimumSlider = new TypedSlider[Int](showLabels = true) {
     min = 0
     max = 100
     value = 0
@@ -60,7 +60,7 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
     colorizeSliderValue(this, ColorMapping.Default.lowerColor)
   }
 
-  private val maximumSlider = new FancySlider {
+  private val maximumSlider = new TypedSlider[Int](showLabels = true) {
     min = 0
     max = 100
     value = 100
@@ -78,8 +78,8 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
     val northedPanel: BorderPanel = new BorderPanel {
       private val slidersPanel = new BorderPanel {
         border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
-        layout(minimumSlider) = BorderPanel.Position.North
-        layout(maximumSlider) = BorderPanel.Position.South
+        layout(minimumSlider.slider) = BorderPanel.Position.North
+        layout(maximumSlider.slider) = BorderPanel.Position.South
         layout(mismatchMessage) = BorderPanel.Position.Center
       }
       layout(slidersPanel) = BorderPanel.Position.Center
@@ -118,8 +118,8 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
 
     // either show sliders, or information
     mismatchMessage.visible = targets.isEmpty
-    minimumSlider.visible = targets.nonEmpty
-    maximumSlider.visible = targets.nonEmpty
+    minimumSlider.slider.visible = targets.nonEmpty
+    maximumSlider.slider.visible = targets.nonEmpty
 
     targets.headOption.foreach { t =>
       val range = t.scalarRange.value
@@ -128,7 +128,7 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
       step = (max - min) / 100.0f
 
       // this is an ugly workaround to make sure (min, max) values are properly displayed
-      def reinitSlider(s: FancySlider): Unit = {
+      def reinitSlider(s: TypedSlider[Int]): Unit = {
         s.min = 1
         s.min = 0
         s.max = 99
@@ -178,7 +178,7 @@ class ScalarRangePropertyPanel(override val frame: ScalismoFrame) extends Border
 
   reactions += {
     case NodeProperty.event.PropertyChanged(_) => updateUi()
-    case ValueChanged(slider) =>
+    case TypedSliderValueChanged(slider) =>
       deafToOwnEvents()
       if (maximumSlider.value < minimumSlider.value) {
         if (slider eq minimumSlider) maximumSlider.value = minimumSlider.value

--- a/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
@@ -23,7 +23,7 @@ import javax.swing.border.TitledBorder
 import scalismo.ui.control.SlicingPosition
 import scalismo.ui.model.{Axis, Scene, SceneNode}
 import scalismo.ui.view.ScalismoFrame
-import scalismo.ui.view.util.{AxisColor, FancySliderDecorator}
+import scalismo.ui.view.util.{AxisColor, TypedSlider, TypedSliderValueChanged}
 
 import scala.swing.GridBagPanel.{Anchor, Fill}
 import scala.swing._
@@ -44,14 +44,7 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
       font = font.deriveFont(font.getStyle | Font.BOLD)
     }
 
-    val slider = new FancySliderDecorator(new Slider {
-
-      min = 0
-      max = 0
-      value = 0
-
-      //override def formattedValue(sliderValue: Int): String = slicingPosition.map(s => s.precision.format(s.precision.fromInt(sliderValue))).getOrElse("?")
-    }, 100.0)
+    val slider = new TypedSlider[Int](true, 0.01)
 
     val minus = new Button(new Action("-") {
       override def apply(): Unit = slider.down()
@@ -161,23 +154,20 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
   }
 
   def deafToOwnEvents(): Unit = {
-    deafTo(x.slider.slider, y.slider.slider, z.slider.slider, slicesVisible)
+    deafTo(x.slider, y.slider, z.slider, slicesVisible)
   }
 
   def listenToOwnEvents(): Unit = {
-    listenTo(x.slider.slider, y.slider.slider, z.slider.slider, slicesVisible)
+    listenTo(x.slider, y.slider, z.slider, slicesVisible)
   }
 
   reactions += {
-    case SlicingPosition.event.VisibilityChanged(_)  => updateUi()
-    case SlicingPosition.event.BoundingBoxChanged(_) => updateUi()
-    case SlicingPosition.event.PointChanged(_, _, _) => updateUi()
-    case ValueChanged(slider: Slider) =>
-      slider match {
-        case x.slider => slicingPosition.foreach(_.x = x.value)
-        case y.slider => slicingPosition.foreach(_.y = y.value)
-        case z.slider => slicingPosition.foreach(_.z = z.value)
-      }
+    case SlicingPosition.event.VisibilityChanged(_)         => updateUi()
+    case SlicingPosition.event.BoundingBoxChanged(_)        => updateUi()
+    case SlicingPosition.event.PointChanged(_, _, _)        => updateUi()
+    case TypedSliderValueChanged(s) if s eq x.slider        => slicingPosition.foreach(_.x = x.value)
+    case TypedSliderValueChanged(s) if s eq y.slider        => slicingPosition.foreach(_.y = y.value)
+    case TypedSliderValueChanged(s) if s eq z.slider        => slicingPosition.foreach(_.z = z.value)
     case ButtonClicked(cb: CheckBox) if cb == slicesVisible => slicingPosition.foreach(_.visible = cb.selected)
   }
 

--- a/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
@@ -23,7 +23,7 @@ import javax.swing.border.TitledBorder
 import scalismo.ui.control.SlicingPosition
 import scalismo.ui.model.{Axis, Scene, SceneNode}
 import scalismo.ui.view.ScalismoFrame
-import scalismo.ui.view.util.{AxisColor, FancySlider, SubDividedSliderAdapter}
+import scalismo.ui.view.util.{AxisColor, FancySliderDecorator}
 
 import scala.swing.GridBagPanel.{Anchor, Fill}
 import scala.swing._
@@ -44,21 +44,21 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
       font = font.deriveFont(font.getStyle | Font.BOLD)
     }
 
-    val slider = new SubDividedSliderAdapter(new FancySlider {
+    val slider = new FancySliderDecorator(new Slider {
 
       min = 0
       max = 0
       value = 0
 
       //override def formattedValue(sliderValue: Int): String = slicingPosition.map(s => s.precision.format(s.precision.fromInt(sliderValue))).getOrElse("?")
-    })
+    }, 100.0)
 
     val minus = new Button(new Action("-") {
-      override def apply(): Unit = slider.down
+      override def apply(): Unit = slider.down()
     })
 
     val plus = new Button(new Action("+") {
-      override def apply(): Unit = slider.up
+      override def apply(): Unit = slider.up()
     })
 
     val control: BorderPanel = new BorderPanel {

--- a/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/SlicingPositionPanel.scala
@@ -23,7 +23,7 @@ import javax.swing.border.TitledBorder
 import scalismo.ui.control.SlicingPosition
 import scalismo.ui.model.{Axis, Scene, SceneNode}
 import scalismo.ui.view.ScalismoFrame
-import scalismo.ui.view.util.{AxisColor, FancySlider}
+import scalismo.ui.view.util.{AxisColor, FancySlider, SubDividedSliderAdapter}
 
 import scala.swing.GridBagPanel.{Anchor, Fill}
 import scala.swing._
@@ -44,38 +44,30 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
       font = font.deriveFont(font.getStyle | Font.BOLD)
     }
 
-    val slider: FancySlider = new FancySlider {
+    val slider = new SubDividedSliderAdapter(new FancySlider {
 
       min = 0
       max = 0
       value = 0
 
       //override def formattedValue(sliderValue: Int): String = slicingPosition.map(s => s.precision.format(s.precision.fromInt(sliderValue))).getOrElse("?")
-    }
+    })
 
     val minus = new Button(new Action("-") {
-      override def apply(): Unit = {
-        if (slider.value > slider.min) {
-          slider.value = slider.value - 1
-        }
-      }
+      override def apply(): Unit = slider.down
     })
 
     val plus = new Button(new Action("+") {
-      override def apply(): Unit = {
-        if (slider.value < slider.max) {
-          slider.value = slider.value + 1
-        }
-      }
+      override def apply(): Unit = slider.up
     })
 
     val control: BorderPanel = new BorderPanel {
       layout(minus) = BorderPanel.Position.West
-      layout(slider) = BorderPanel.Position.Center
+      layout(slider.slider) = BorderPanel.Position.Center
       layout(plus) = BorderPanel.Position.East
     }
 
-    def value: Float = {
+    def value: Double = {
       slider.value
     }
 
@@ -86,9 +78,9 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
         case Axis.Y => (sp.boundingBox.yMin, sp.boundingBox.yMax, sp.y)
         case Axis.Z => (sp.boundingBox.zMin, sp.boundingBox.zMax, sp.z)
       }
-      slider.min = Math.floor(min).toInt
-      slider.max = Math.ceil(max).toInt
-      slider.value = Math.round(value).toInt
+      slider.min = min
+      slider.max = max
+      slider.value = value
     }
 
   }
@@ -169,11 +161,11 @@ class SlicingPositionPanel(override val frame: ScalismoFrame) extends BorderPane
   }
 
   def deafToOwnEvents(): Unit = {
-    deafTo(x.slider, y.slider, z.slider, slicesVisible)
+    deafTo(x.slider.slider, y.slider.slider, z.slider.slider, slicesVisible)
   }
 
   def listenToOwnEvents(): Unit = {
-    listenTo(x.slider, y.slider, z.slider, slicesVisible)
+    listenTo(x.slider.slider, y.slider.slider, z.slider.slider, slicesVisible)
   }
 
   reactions += {

--- a/src/main/scala/scalismo/ui/view/properties/WindowLevelPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/WindowLevelPropertyPanel.scala
@@ -26,12 +26,11 @@ import scalismo.ui.model.properties.NodeProperty
 import scalismo.ui.model.{ImageNode, SceneNode}
 import scalismo.ui.view.ScalismoFrame
 import scalismo.ui.view.properties.WindowLevelPropertyPanel.Showit
-import scalismo.ui.view.util.FancySlider
 import scalismo.ui.view.util.ScalableUI.implicits.scalableInt
+import scalismo.ui.view.util.{TypedSlider, TypedSliderValueChanged}
 
 import scala.swing.Swing.EmptyIcon
 import scala.swing._
-import scala.swing.event.ValueChanged
 
 object WindowLevelPropertyPanel extends PropertyPanel.Factory {
   override def create(frame: ScalismoFrame): PropertyPanel = new WindowLevelPropertyPanel(frame)
@@ -109,8 +108,8 @@ class WindowLevelPropertyPanel(override val frame: ScalismoFrame) extends Border
 
   var targets: List[ImageNode] = Nil
 
-  val levelSlider = new FancySlider
-  val windowSlider = new FancySlider
+  val levelSlider = new TypedSlider[Int](showLabels = true)
+  val windowSlider = new TypedSlider[Int](showLabels = true)
 
   val showit = new Showit
 
@@ -174,12 +173,12 @@ class WindowLevelPropertyPanel(override val frame: ScalismoFrame) extends Border
   }
 
   reactions += {
-    case ValueChanged(s: Slider) if s eq windowSlider =>
+    case TypedSliderValueChanged(s) if s eq windowSlider =>
       targets.foreach { n =>
         val updated = n.windowLevel.value.copy(window = windowSlider.value)
         n.windowLevel.value = updated
       }
-    case ValueChanged(s: Slider) if s eq levelSlider =>
+    case TypedSliderValueChanged(s) if s eq levelSlider =>
       targets.foreach { n =>
         val updated = n.windowLevel.value.copy(level = levelSlider.value)
         n.windowLevel.value = updated
@@ -222,9 +221,9 @@ class WindowLevelPropertyPanel(override val frame: ScalismoFrame) extends Border
         }
 
         add(new Label("Level", EmptyIcon, Alignment.Leading), next)
-        add(levelSlider, next)
+        add(levelSlider.slider, next)
         add(new Label("Window", EmptyIcon, Alignment.Leading), next)
-        add(windowSlider, next)
+        add(windowSlider.slider, next)
       }
 
       private val showitWrap = new BorderPanel {

--- a/src/main/scala/scalismo/ui/view/util/FancySlider.scala
+++ b/src/main/scala/scalismo/ui/view/util/FancySlider.scala
@@ -20,7 +20,7 @@ package scalismo.ui.view.util
 import java.awt.Color
 
 import scala.swing.event.ValueChanged
-import scala.swing.{Label, Slider}
+import scala.swing.{Label, Reactor, Slider}
 
 class FancySlider extends Slider {
   // intended to be overwritten in subclasses if needed
@@ -55,4 +55,44 @@ class FancySlider extends Slider {
   reactions += {
     case ValueChanged(c) if c eq this => updateLabels()
   }
+}
+
+class FancySliderDecorator(override val slider: Slider, override val factor: Double)
+    extends SubDividedSliderAdapter(slider, factor) {
+
+  // intended to be overwritten in subclasses if needed
+  def formattedValue(sliderValue: Double): String = sliderValue.toInt.toString
+
+  val minLabel: Label = new Label {
+    foreground = Color.GRAY
+  }
+
+  val maxLabel: Label = new Label {
+    foreground = Color.GRAY
+  }
+
+  val valueLabel: Label = new Label {
+    foreground = Color.BLACK
+  }
+
+  protected def updateLabels(): Unit = {
+    if (slider.paintLabels) {
+      val texts = Seq(min, max, value) map formattedValue
+      val tuples = texts.zip(Seq(minLabel, maxLabel, valueLabel))
+      val needsUpdate = tuples.exists { case (v, l) => l.text != v }
+      if (needsUpdate) {
+        tuples.foreach { case (v, l) => l.text = v }
+        slider.labels =
+          Seq((slider.min, minLabel), (slider.max, maxLabel), (slider.value, valueLabel)).filter(_._2.visible).toMap
+      }
+    }
+  }
+
+  listenTo(slider)
+
+  reactions += {
+    case ValueChanged(c) if c eq slider => updateLabels()
+  }
+
+  slider.paintLabels = true
 }

--- a/src/main/scala/scalismo/ui/view/util/SubDividedSliderAdapter.scala
+++ b/src/main/scala/scalismo/ui/view/util/SubDividedSliderAdapter.scala
@@ -17,28 +17,53 @@
 
 package scalismo.ui.view.util
 
-import scala.swing.Slider
+import javax.swing.JComponent
+import scalismo.ui.event.ScalismoPublisher
 
-class SubDividedSliderAdapter(private val _slider: Slider, private val factor: Double = 100.0) {
+import scala.swing.{Component, Slider}
+import scala.swing.event.ValueChanged
 
-  def slider: Slider = _slider
+class SubDividedSliderAdapter(val slider: Slider, val factor: Double = 100.0) extends Component with ScalismoPublisher {
+
+  override lazy val peer: JComponent = slider.peer
 
   def up(): Unit = {
-    if (_slider.value < _slider.max) {
-      _slider.value = _slider.value + 1
+    if (slider.value < slider.max) {
+      slider.value = slider.value + 1
     }
   }
 
   def down(): Unit = {
-    if (_slider.value > _slider.min) {
-      _slider.value = _slider.value - 1
+    if (slider.value > slider.min) {
+      slider.value = slider.value - 1
     }
   }
 
-  def min: Double = _slider.min / factor
-  def min_=(v: Double) { _slider.min = Math.floor(v * factor).toInt }
-  def max: Double = _slider.max / factor
-  def max_=(v: Double) { _slider.max = Math.ceil(v * factor).toInt }
-  def value: Double = _slider.value / factor
-  def value_=(v: Double) { _slider.value = Math.round(v * factor).toInt }
+  def min: Double = slider.min / factor
+
+  def min_=(v: Double) {
+    slider.min = Math.floor(v * factor).toInt
+  }
+
+  def max: Double = slider.max / factor
+
+  def max_=(v: Double) {
+    slider.max = Math.ceil(v * factor).toInt
+  }
+
+  def value: Double = slider.value / factor
+
+  def value_=(v: Double) {
+    slider.value = Math.round(v * factor).toInt
+  }
+
+  def listenToOwnEvents() = listenTo(slider)
+
+  def deafToOwnEvents() = deafTo(slider)
+
+  reactions += {
+    case ValueChanged(s: Slider) if s == slider => publishEvent(new ValueChanged(SubDividedSliderAdapter.this))
+  }
+
+  listenToOwnEvents()
 }

--- a/src/main/scala/scalismo/ui/view/util/SubDividedSliderAdapter.scala
+++ b/src/main/scala/scalismo/ui/view/util/SubDividedSliderAdapter.scala
@@ -21,15 +21,15 @@ import scala.swing.Slider
 
 class SubDividedSliderAdapter(private val _slider: Slider, private val factor: Double = 100.0) {
 
-  def slider = _slider
+  def slider: Slider = _slider
 
-  def up = {
+  def up(): Unit = {
     if (_slider.value < _slider.max) {
       _slider.value = _slider.value + 1
     }
   }
 
-  def down = {
+  def down(): Unit = {
     if (_slider.value > _slider.min) {
       _slider.value = _slider.value - 1
     }

--- a/src/main/scala/scalismo/ui/view/util/SubDividedSliderAdapter.scala
+++ b/src/main/scala/scalismo/ui/view/util/SubDividedSliderAdapter.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016  University of Basel, Graphics and Vision Research Group
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scalismo.ui.view.util
+
+import scala.swing.Slider
+
+class SubDividedSliderAdapter(private val _slider: Slider, private val factor: Double = 100.0) {
+
+  def slider = _slider
+
+  def up = {
+    if (_slider.value < _slider.max) {
+      _slider.value = _slider.value + 1
+    }
+  }
+
+  def down = {
+    if (_slider.value > _slider.min) {
+      _slider.value = _slider.value - 1
+    }
+  }
+
+  def min: Double = _slider.min / factor
+  def min_=(v: Double) { _slider.min = Math.floor(v * factor).toInt }
+  def max: Double = _slider.max / factor
+  def max_=(v: Double) { _slider.max = Math.ceil(v * factor).toInt }
+  def value: Double = _slider.value / factor
+  def value_=(v: Double) { _slider.value = Math.round(v * factor).toInt }
+}

--- a/src/main/scala/scalismo/ui/view/util/TypedSlider.scala
+++ b/src/main/scala/scalismo/ui/view/util/TypedSlider.scala
@@ -1,0 +1,114 @@
+package scalismo.ui.view.util
+
+import scalismo.ui.event.ScalismoPublisher
+import java.awt.Color
+
+import scala.swing.{Component, Label, Slider}
+import scala.swing.event.{Event, ValueChanged}
+
+class TypedSlider[A: Numeric](showLabels: Boolean = false, val stepSize: Double = 1.0)(
+  implicit getValue: CanCreateFromDouble[A]
+) extends ScalismoPublisher {
+
+  val slider = new Slider()
+
+  protected def toSliderValue(outer: Double): Int = {
+    (outer / stepSize).round.toInt
+  }
+
+  protected def fromSliderValue(inner: Int): A = {
+    getValue.fromDouble(inner * stepSize)
+  }
+
+  def up(): Unit = {
+    if (slider.value < slider.max) {
+      slider.value = slider.value + 1
+    }
+  }
+
+  def down(): Unit = {
+    if (slider.value > slider.min) {
+      slider.value = slider.value - 1
+    }
+  }
+
+  def min: A = fromSliderValue(slider.min)
+
+  def min_=(value: Double) {
+    slider.min = Math.floor(toSliderValue(value)).toInt
+  }
+
+  def max: A = fromSliderValue(slider.max)
+
+  def max_=(value: Double) {
+    slider.max = Math.ceil(toSliderValue(value)).toInt
+  }
+
+  def value: A = fromSliderValue(slider.value)
+
+  def value_=(value: Double) {
+    slider.value = toSliderValue(value)
+  }
+
+  // intended to be overwritten in subclasses if needed
+  def formattedValue(sliderValue: A): String = sliderValue.toString
+
+  val minLabel: Label = new Label {
+    foreground = Color.GRAY
+  }
+
+  val maxLabel: Label = new Label {
+    foreground = Color.GRAY
+  }
+
+  val valueLabel: Label = new Label {
+    foreground = Color.BLACK
+  }
+
+  protected def updateLabels(): Unit = {
+    if (slider.paintLabels) {
+      val texts = Seq(min, max, value) map formattedValue
+      val tuples = texts.zip(Seq(minLabel, maxLabel, valueLabel))
+      val needsUpdate = tuples.exists { case (v, l) => l.text != v }
+      if (needsUpdate) {
+        tuples.foreach { case (v, l) => l.text = v }
+        slider.labels =
+          Seq((slider.min, minLabel), (slider.max, maxLabel), (slider.value, valueLabel)).filter(_._2.visible).toMap
+      }
+    }
+  }
+
+  def listenToOwnEvents(): Unit = listenTo(slider)
+
+  def deafToOwnEvents(): Unit = deafTo(slider)
+
+  reactions += {
+    case ValueChanged(s) if s eq slider => {
+      if (slider.paintLabels) updateLabels()
+      publishEvent(new TypedSliderValueChanged(TypedSlider.this))
+    }
+  }
+
+  listenToOwnEvents()
+
+  slider.paintLabels = showLabels
+
+}
+
+case class TypedSliderValueChanged[A: Numeric](source: TypedSlider[A]) extends Event
+
+trait CanCreateFromDouble[A] { def fromDouble(d: Double): A }
+
+object CanCreateFromDouble {
+  implicit object CanCreateIntFromDouble extends CanCreateFromDouble[Int] {
+    def fromDouble(value: Double): Int = value.round.toInt
+  }
+
+  implicit object CanCreateFloatFromDouble extends CanCreateFromDouble[Float] {
+    def fromDouble(value: Double): Float = value.toFloat
+  }
+
+  implicit object CanCreateDoubleFromDouble extends CanCreateFromDouble[Double] {
+    def fromDouble(value: Double): Double = value.toDouble
+  }
+}


### PR DESCRIPTION
This PR fixes #50 by introducing a new class [SubDividedSliderAdapter](https://github.com/Andreas-Forster/scalismo-ui/blob/098d92cfd6bf82fb3bdbe9c4ccc46412a0a6ecb0/src/main/scala/scalismo/ui/view/util/SubDividedSliderAdapter.scala#L22). The sliders have by default a 100x finer resolution than now. This should fix for most use cases the issue #50 where the slices could not be made visible by using the sliders.