### PR TITLE
added scaling to LandmarkNode

### DIFF
--- a/src/main/scala/scalismo/ui/api/ShowInScene.scala
+++ b/src/main/scala/scalismo/ui/api/ShowInScene.scala
@@ -226,26 +226,27 @@ object ShowInScene extends LowPriorityImplicits {
 
   }
 
-  implicit object ShowInScenePointDistributionModelTriangleMesh3D extends ShowInScene[PointDistributionModel[_3D, TriangleMesh]] {
-      override type View = PointDistributionModelViewControlsTriangleMesh3D
+  implicit object ShowInScenePointDistributionModelTriangleMesh3D
+      extends ShowInScene[PointDistributionModel[_3D, TriangleMesh]] {
+    override type View = PointDistributionModelViewControlsTriangleMesh3D
 
-      override def showInScene(model: PointDistributionModel[_3D, TriangleMesh], name: String, group: Group): View = {
-        val gpUnstructuredPoints = model.gp
-          .interpolate(NearestNeighborInterpolator3D())
-          .discretize(UnstructuredPointsDomain(model.reference.pointSet.points.toIndexedSeq))
+    override def showInScene(model: PointDistributionModel[_3D, TriangleMesh], name: String, group: Group): View = {
+      val gpUnstructuredPoints = model.gp
+        .interpolate(NearestNeighborInterpolator3D())
+        .discretize(UnstructuredPointsDomain(model.reference.pointSet.points.toIndexedSeq))
 
-        val shapeModelTransform =
-          ShapeModelTransformation(PointTransformation.RigidIdentity,
-            DiscreteLowRankGpPointTransformation(gpUnstructuredPoints))
-        val smV = CreateShapeModelTransformation.showInScene(shapeModelTransform, name, group)
-        val tmV = ShowInSceneMesh.showInScene(model.reference, name, group)
-        PointDistributionModelViewControlsTriangleMesh3D(tmV, smV)
+      val shapeModelTransform =
+        ShapeModelTransformation(PointTransformation.RigidIdentity,
+                                 DiscreteLowRankGpPointTransformation(gpUnstructuredPoints))
+      val smV = CreateShapeModelTransformation.showInScene(shapeModelTransform, name, group)
+      val tmV = ShowInSceneMesh.showInScene(model.reference, name, group)
+      PointDistributionModelViewControlsTriangleMesh3D(tmV, smV)
 
-      }
     }
+  }
 
-
-  implicit object ShowInScenePointDistributionModelTetrahedralMesh3D extends ShowInScene[PointDistributionModel[_3D, TetrahedralMesh]] {
+  implicit object ShowInScenePointDistributionModelTetrahedralMesh3D
+      extends ShowInScene[PointDistributionModel[_3D, TetrahedralMesh]] {
     override type View = PointDistributionModelViewControlsTetrahedralMesh3D
 
     override def showInScene(model: PointDistributionModel[_3D, TetrahedralMesh], name: String, group: Group): View = {
@@ -255,14 +256,13 @@ object ShowInScene extends LowPriorityImplicits {
 
       val shapeModelTransform =
         ShapeModelTransformation(PointTransformation.RigidIdentity,
-          DiscreteLowRankGpPointTransformation(gpUnstructuredPoints))
+                                 DiscreteLowRankGpPointTransformation(gpUnstructuredPoints))
       val smV = CreateShapeModelTransformation.showInScene(shapeModelTransform, name, group)
       val tmV = ShowTetrahedralMesh.showInScene(model.reference, name, group)
       PointDistributionModelViewControlsTetrahedralMesh3D(tmV, smV)
 
     }
   }
-
 
   implicit object ShowInSceneStatisticalMeshModel extends ShowInScene[StatisticalMeshModel] {
     type View = StatisticalMeshModelViewControls

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -440,6 +440,12 @@ case class LandmarkView private[ui] (override protected[api] val peer: LandmarkN
     peer.opacity.value = o
   }
 
+  def scalingFactor: Double = peer.scaling.value
+
+  def scalingFactor_=(o: Double): Unit = {
+    peer.scaling.value = o
+  }
+
   def landmark: Landmark[_3D] = peer.source
 
   def transformedLandmark: Landmark[_3D] = peer.transformedSource
@@ -723,13 +729,11 @@ case class PointDistributionModelViewControlsTriangleMesh3D private[ui] (
   shapeModelTransformationView: ShapeModelTransformationView
 )
 
-
 // Note this class does not extend Object view, as there is not really a corresponding node to this concept
 case class PointDistributionModelViewControlsTetrahedralMesh3D private[ui] (
-                                                                          referenceView: TetrahedralMeshView,
-                                                                          shapeModelTransformationView: ShapeModelTransformationView
-                                                                        )
-
+  referenceView: TetrahedralMeshView,
+  shapeModelTransformationView: ShapeModelTransformationView
+)
 
 case class Group(override protected[api] val peer: GroupNode) extends ObjectView {
 

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -442,8 +442,8 @@ case class LandmarkView private[ui] (override protected[api] val peer: LandmarkN
 
   def scalingFactor: Double = peer.scaling.value
 
-  def scalingFactor_=(o: Double): Unit = {
-    peer.scaling.value = o
+  def scalingFactor_=(s: Double): Unit = {
+    peer.scaling.value = s
   }
 
   def landmark: Landmark[_3D] = peer.source

--- a/src/main/scala/scalismo/ui/model/LandmarkNode.scala
+++ b/src/main/scala/scalismo/ui/model/LandmarkNode.scala
@@ -118,6 +118,7 @@ class LandmarkNode(override val parent: LandmarksNode, sourceLm: Landmark[_3D])
     with HasColor
     with HasOpacity
     with HasLineWidth
+    with HasScaling
     with HasPickable {
   name = sourceLm.id
 
@@ -125,6 +126,7 @@ class LandmarkNode(override val parent: LandmarksNode, sourceLm: Landmark[_3D])
   override val opacity = new OpacityProperty()
   override val lineWidth = new LineWidthProperty()
   override val pickable = new PickableProperty()
+  override val scaling: ScalingProperty = new ScalingProperty(1)
 
   // lazy is needed here since traits such as Transformable call source() which need uncertainty, all this at *construction time*
   override lazy val uncertainty = new UncertaintyProperty(
@@ -146,4 +148,5 @@ class LandmarkNode(override val parent: LandmarksNode, sourceLm: Landmark[_3D])
   }
 
   override def group: GroupNode = parent.parent
+
 }

--- a/src/main/scala/scalismo/ui/model/properties/ScalingProperty.scala
+++ b/src/main/scala/scalismo/ui/model/properties/ScalingProperty.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016  University of Basel, Graphics and Vision Research Group
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scalismo.ui.model.properties
+
+object ScalingProperty {
+  val DefaultValue: Double = 1.0
+
+}
+
+class ScalingProperty(initialValue: Double) extends NodeProperty[Double](initialValue) {
+  def this() = this(ScalingProperty.DefaultValue)
+
+  override protected def sanitize(possiblyNotSane: Double): Double = {
+    Math.max(0, possiblyNotSane)
+  }
+}
+
+trait HasScaling {
+  def scaling: ScalingProperty
+}

--- a/src/main/scala/scalismo/ui/model/properties/ScalingProperty.scala
+++ b/src/main/scala/scalismo/ui/model/properties/ScalingProperty.scala
@@ -26,7 +26,7 @@ class ScalingProperty(initialValue: Double) extends NodeProperty[Double](initial
   def this() = this(ScalingProperty.DefaultValue)
 
   override protected def sanitize(possiblyNotSane: Double): Double = {
-    Math.max(0, possiblyNotSane)
+    Math.max(Double.MinPositiveValue, possiblyNotSane)
   }
 }
 

--- a/src/main/scala/scalismo/ui/rendering/actor/LandmarkActor.scala
+++ b/src/main/scala/scalismo/ui/rendering/actor/LandmarkActor.scala
@@ -88,19 +88,20 @@ trait LandmarkActor extends ActorColor with ActorOpacity with ActorSceneNode {
       val center = sceneNode.transformedSource.point
       transform.Translate(center(0), center(1), center(2))
 
-      ellipsoid.SetXRadius(xRadius)
-      ellipsoid.SetYRadius(yRadius)
-      ellipsoid.SetZRadius(zRadius)
+      ellipsoid.SetXRadius(xRadius * sceneNode.scaling.value)
+      ellipsoid.SetYRadius(yRadius * sceneNode.scaling.value)
+      ellipsoid.SetZRadius(zRadius * sceneNode.scaling.value)
     }
 
     actorChanged(geometryChanged)
   }
 
-  listenTo(sceneNode, sceneNode.uncertainty)
+  listenTo(sceneNode, sceneNode.uncertainty, sceneNode.scaling)
 
   reactions += {
-    case Transformable.event.GeometryChanged(_)                              => rerender(true)
-    case NodeProperty.event.PropertyChanged(p) if p == sceneNode.uncertainty => rerender(true)
+    case Transformable.event.GeometryChanged(_) => rerender(true)
+    case NodeProperty.event.PropertyChanged(p) if p == sceneNode.uncertainty || p == sceneNode.scaling =>
+      rerender(true)
   }
 
   protected def onInstantiated(): Unit

--- a/src/main/scala/scalismo/ui/view/NodePropertiesPanel.scala
+++ b/src/main/scala/scalismo/ui/view/NodePropertiesPanel.scala
@@ -42,6 +42,7 @@ object NodePropertiesPanel {
       props += ScalarRangePropertyPanel
       props += OpacityPropertyPanel
       props += RadiusPropertyPanel
+      props += ScalingPropertyPanel
       props += LineWidthPropertyPanel
 
       new CombinedPropertiesPanel(frame, "Appearance", props.toList.map(c => c(frame)): _*)

--- a/src/main/scala/scalismo/ui/view/properties/ScalingPropertyPanel.scala
+++ b/src/main/scala/scalismo/ui/view/properties/ScalingPropertyPanel.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2016  University of Basel, Graphics and Vision Research Group
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scalismo.ui.view.properties
+
+import javax.swing.border.TitledBorder
+import scalismo.ui.model.SceneNode
+import scalismo.ui.model.properties.{HasRadius, HasScaling, NodeProperty}
+import scalismo.ui.view.ScalismoFrame
+import scalismo.ui.view.util.FloatSlider
+
+import scala.swing.BorderPanel
+import scala.swing.event.ValueChanged
+
+object ScalingPropertyPanel extends PropertyPanel.Factory {
+  override def create(frame: ScalismoFrame): PropertyPanel = {
+    new ScalingPropertyPanel(frame)
+  }
+
+  val MinValue: Float = 0.0f
+  val MaxValue: Float = 5.0f
+  val StepSize: Float = 0.05f
+}
+
+class ScalingPropertyPanel(override val frame: ScalismoFrame) extends BorderPanel with PropertyPanel {
+  override def description: String = "Scaling factor"
+
+  private var targets: List[HasScaling] = Nil
+
+  private val slider =
+    new FloatSlider(ScalingPropertyPanel.MinValue, ScalingPropertyPanel.MaxValue, ScalingPropertyPanel.StepSize)
+
+  layout(new BorderPanel {
+    private val sliderPanel = new BorderPanel {
+      border = new TitledBorder(null, description, TitledBorder.LEADING, 0, null, null)
+      layout(slider) = BorderPanel.Position.Center
+    }
+    layout(sliderPanel) = BorderPanel.Position.Center
+  }) = BorderPanel.Position.North
+
+  listenToOwnEvents()
+
+  def listenToOwnEvents(): Unit = {
+    listenTo(slider)
+  }
+
+  def deafToOwnEvents(): Unit = {
+    deafTo(slider)
+  }
+
+  def updateUi(): Unit = {
+    deafToOwnEvents()
+    targets.headOption.foreach(t => slider.floatValue = t.scaling.value.toFloat)
+    listenToOwnEvents()
+  }
+
+  override def setNodes(nodes: List[SceneNode]): Boolean = {
+    cleanup()
+    val supported = allMatch[HasScaling](nodes)
+    if (supported.nonEmpty) {
+      targets = supported
+      listenTo(targets.head.scaling)
+      updateUi()
+      true
+    } else false
+  }
+
+  def cleanup(): Unit = {
+    targets.headOption.foreach(t => deafTo(t.scaling))
+    targets = Nil
+  }
+
+  reactions += {
+    case NodeProperty.event.PropertyChanged(_) => updateUi()
+    case ValueChanged(_)                       => targets.foreach(_.scaling.value = slider.floatValue)
+  }
+
+}


### PR DESCRIPTION
Landmarks are visualized using an ellipsoid. So far, the size of this ellipsoid was chosen to reflect one standard deviation of its associated uncertainty. This commit adds the possibility to scale this ellipsoid with a fixed scale factor. This is useful when the uncertainty is very small or large in relationship to the visualized object.

The implementation adds a new ScalingProperty and ScalingPropertyPanel, which could be reused for adding this property to other nodes.