### PR TITLE
Vtk9 1 bugfixes

### DIFF
--- a/src/main/scala/scalismo/ui/rendering/internal/EventInterceptor.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/EventInterceptor.scala
@@ -18,7 +18,6 @@
 package scalismo.ui.rendering.internal
 
 import java.awt.event.{KeyEvent, MouseEvent, MouseWheelEvent, MouseWheelListener}
-
 import scalismo.ui.control.interactor.Interactor.Verdict.Block
 import scalismo.ui.view.ScalismoFrame
 import vtk.rendering.vtkEventInterceptor
@@ -45,7 +44,5 @@ class EventInterceptor(frame: ScalismoFrame) extends vtkEventInterceptor {
 
   override def mouseReleased(e: MouseEvent): Boolean = frame.interactor.mouseReleased(e) == Block
 
-  // This is an extension to the original vtkEventInterceptor.
-  // Since VTK doesn't handle mouse wheel events anyway, there's no need to block them, hence a Unit return type.
   override def mouseWheelMoved(e: MouseWheelEvent): Boolean = frame.interactor.mouseWheelMoved(e) == Block
 }

--- a/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package scalismo.ui.rendering.internal
 
 import com.jogamp.opengl.{GLAutoDrawable, GLCapabilities, GLEventListener, GLProfile}
@@ -35,7 +36,7 @@ class RenderingComponent(viewport: ViewportPanel) extends vtk.rendering.jogl.vtk
 
   private lazy val interceptor = new EventInterceptor(viewport.frame)
   private lazy val interactor = new RenderWindowInteractor()
-  private lazy val glPanel = new GLJPanelWithViewport(viewport, new GLCapabilities(GLProfile.getDefault()))
+  private lazy val glPanel = new GLJPanelWithViewport(viewport, new GLCapabilities(GLProfile.getMaximum(true)))
 
   val rendererState = new RendererStateImplementation(renderer, viewport)
 

--- a/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
+++ b/src/main/scala/scalismo/ui/rendering/internal/RenderingComponent.scala
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package scalismo.ui.rendering.internal
 
 import com.jogamp.opengl.{GLAutoDrawable, GLCapabilities, GLEventListener, GLProfile}
@@ -23,18 +22,141 @@ import com.jogamp.opengl.awt.GLJPanel
 import java.util.concurrent.locks.ReentrantLock
 import scalismo.ui.view.ViewportPanel
 import vtk._
-import vtk.rendering.jogl.vtkJoglPanelComponent
+
+import java.awt.event.{MouseWheelEvent, MouseWheelListener}
 
 /**
- * A minor extension of vtkJoglPanelComponent.
+ * An extension of vtkJoglPanelComponent.
  *
- * Note:  This component is here mainly for historical purposes. When Scalismo used
- * jogl 2.2 and older, parts of the functionality was reimplemented. With jogl 2.4 this
- * does not seem to be strictly necessary anymore. We keep the rendererState here, until we
- * have a good idea how to refactor tat.
+ * It provides functionality for controlling (blocking) events and also provides
+ * deferred rendering for greater efficiency
  */
 class RenderingComponent(viewport: ViewportPanel) extends vtk.rendering.jogl.vtkJoglPanelComponent {
 
+  private lazy val interceptor = new EventInterceptor(viewport.frame)
+  private lazy val interactor = new RenderWindowInteractor()
+  private lazy val glPanel = new GLJPanelWithViewport(viewport, new GLCapabilities(GLProfile.getDefault()))
+
   val rendererState = new RendererStateImplementation(renderer, viewport)
-  def render() = super.Render()
+
+  eventForwarder.setEventInterceptor(interceptor)
+
+  interactor.SetRenderWindow(renderWindow)
+  interactor.TimerEventResetsTimerOff()
+  interactor.ConfigureEvent()
+  interactor.SetInteractorStyle(new vtkInteractorStyleTrackballCamera)
+
+  interactor.AddObserver("CreateTimerEvent", eventForwarder, "StartTimer")
+  interactor.AddObserver("DestroyTimerEvent", eventForwarder, "DestroyTimer")
+
+  renderWindow.AddRenderer(renderer)
+
+  // Make sure that when VTK internally requests a Render, it gets triggered properly
+  renderWindow.AddObserver("WindowFrameEvent", this, "Render")
+  renderWindow.GetInteractor.AddObserver("RenderEvent", this, "Render")
+  renderWindow.GetInteractor.SetEnableRender(false)
+
+  // Bind interactor forwarder
+  glPanel.addMouseListener(eventForwarder)
+  glPanel.addMouseMotionListener(eventForwarder)
+  glPanel.addKeyListener(eventForwarder)
+
+  object MouseWheelEventInterceptorAdapter extends MouseWheelListener {
+    override def mouseWheelMoved(e: MouseWheelEvent): Unit = interceptor.mouseWheelMoved(e)
+  }
+  glPanel.addMouseWheelListener(MouseWheelEventInterceptorAdapter)
+
+  glPanel.addGLEventListener(new GLEventListener {
+
+    override def init(drawable: GLAutoDrawable): Unit = {
+      // Make sure the JOGL context is current
+      val ctx = drawable.getContext
+      if (!ctx.isCurrent) {
+        ctx.makeCurrent()
+      }
+
+      // Init VTK OpenGL RenderWindow
+      renderWindow.SetPosition(0, 0)
+
+      setSize(drawable.getSurfaceWidth, drawable.getSurfaceHeight)
+    }
+
+    override def reshape(drawable: GLAutoDrawable, x: Int, y: Int, width: Int, height: Int): Unit = {
+      setSize(width, height)
+    }
+
+    override def display(drawable: GLAutoDrawable): Unit = {
+      inRenderCall = true
+      renderWindow.Render()
+      inRenderCall = false
+    }
+
+    override def dispose(drawable: GLAutoDrawable): Unit = {
+      Delete()
+      vtkObjectBase.JAVA_OBJECT_MANAGER.gc(false)
+    }
+  })
+
+  private def executeLocked(block: => Unit): Unit = {
+    lock.lock()
+    block
+    lock.unlock()
+  }
+
+  private def executeInterruptibly(block: => Unit): Unit = {
+    try {
+      lock.lockInterruptibly()
+      block
+    } catch {
+      case _: InterruptedException => // nothing we can do
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  override def getComponent: GLJPanel = glPanel
+
+  override def Render(): Unit = {
+    if (!inRenderCall) {
+      glPanel.repaint()
+    }
+  }
+
+  override def getRenderer: vtkRenderer = renderer
+
+  override def getVTKLock: ReentrantLock = lock
+
+  override def getRenderWindowInteractor: RenderWindowInteractor = interactor
+
+  override def resetCameraClippingRange(): Unit = {
+    if (renderer != null) {
+      executeInterruptibly(renderer.ResetCameraClippingRange())
+    }
+  }
+
+  override def setInteractorStyle(style: vtkInteractorStyle): Unit = {
+    if (interactor != null) {
+      executeLocked(interactor.SetInteractorStyle(style))
+    }
+  }
+
+  override def setSize(w: Int, h: Int): Unit = {
+    if (renderWindow != null && interactor != null) {
+      executeInterruptibly {
+        rendererState.setSize(w, h, glPanel)
+        renderWindow.SetSize(w, h)
+        interactor.SetSize(w, h)
+      }
+    }
+  }
+
+  private val deferred = new DeferredRendering(Render())
+
+  def render(allowDeferred: Boolean = true): Unit = {
+    if (!allowDeferred) {
+      Render()
+    } else {
+      deferred.request()
+    }
+  }
 }


### PR DESCRIPTION
In the transitioning to vtk 9.1, we accidentally dropped the code that was necessary for correct handling of events in the vtk windows. As a result the mouse wheel no longer worked and the 2D planes could be moved. This commit fixes the problem by reintroducing the functionality that was dropped before.