### PR TITLE
add an implicit ShowInScene Object for PDM[UnstructuredPointsDomain3D]

### DIFF
--- a/src/main/scala/scalismo/ui/api/ShowInScene.scala
+++ b/src/main/scala/scalismo/ui/api/ShowInScene.scala
@@ -245,6 +245,27 @@ object ShowInScene extends LowPriorityImplicits {
     }
   }
 
+  implicit object ShowInScenePointDistributionModelUnstructuredPointsDomain3D
+      extends ShowInScene[PointDistributionModel[_3D, UnstructuredPointsDomain]] {
+    override type View = PointDistributionModelViewControlsUnstructuredPointsDomain3D
+
+    override def showInScene(model: PointDistributionModel[_3D, UnstructuredPointsDomain],
+                             name: String,
+                             group: Group): View = {
+      val gpUnstructuredPoints = model.gp
+        .interpolate(NearestNeighborInterpolator3D())
+        .discretize(UnstructuredPointsDomain(model.reference.pointSet.points.toIndexedSeq))
+
+      val shapeModelTransform =
+        ShapeModelTransformation(PointTransformation.RigidIdentity,
+                                 DiscreteLowRankGpPointTransformation(gpUnstructuredPoints))
+      val smV = CreateShapeModelTransformation.showInScene(shapeModelTransform, name, group)
+      val tmV = ShowInScenePointCloudFromDomain.showInScene(model.reference, name, group)
+      PointDistributionModelViewControlsUnstructuredPointsDomain3D(tmV, smV)
+
+    }
+  }
+
   implicit object ShowInScenePointDistributionModelTetrahedralMesh3D
       extends ShowInScene[PointDistributionModel[_3D, TetrahedralMesh]] {
     override type View = PointDistributionModelViewControlsTetrahedralMesh3D

--- a/src/main/scala/scalismo/ui/api/Views.scala
+++ b/src/main/scala/scalismo/ui/api/Views.scala
@@ -730,6 +730,12 @@ case class PointDistributionModelViewControlsTriangleMesh3D private[ui] (
 )
 
 // Note this class does not extend Object view, as there is not really a corresponding node to this concept
+case class PointDistributionModelViewControlsUnstructuredPointsDomain3D private[ui] (
+  referenceView: PointCloudView,
+  shapeModelTransformationView: ShapeModelTransformationView
+)
+
+// Note this class does not extend Object view, as there is not really a corresponding node to this concept
 case class PointDistributionModelViewControlsTetrahedralMesh3D private[ui] (
   referenceView: TetrahedralMeshView,
   shapeModelTransformationView: ShapeModelTransformationView


### PR DESCRIPTION
In scalismo we can easily create Point distribution models over point clouds, by simply setting the domain to UnstructuredPointsDomain. So far, the capability to visualize those models in Scalismo-ui was missing. This commit adds the necessary objects.